### PR TITLE
Fix typos and grammar errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 The WorkIQ CLI and MCP (Model Context Protocol) server connects AI assistants to your Microsoft 365 Copilot data. Ask questions like *"What did my manager say about the project deadline?"* or *"Find my recent documents about Q4 planning."*
 
-To access Microsoft 365 tenant data, the WorkIQ CLI and MCP Server need to be consented to permissions that require administrative rights on the tenant.On first access, a consent dialog appears. If you are not an administrator, contact your tenant administrator to grant access.
+To access Microsoft 365 tenant data, the WorkIQ CLI and MCP Server need to be consented to permissions that require administrative rights on the tenant. On first access, a consent dialog appears. If you are not an administrator, contact your tenant administrator to grant access.
 
 **For Tenant Administrators:** See the [Tenant Administrator Enablement Guide](./ADMIN-INSTRUCTIONS.md) for detailed instructions on granting admin consent, including a quick one-click consent URL.
 
@@ -62,7 +62,7 @@ Or use npx without installing:
 npx -y @microsoft/workiq mcp
 ```
 
-Or add it as a MCP server in your coding agent or IDE:
+Or add it as an MCP server in your coding agent or IDE:
 
 ```json
 {
@@ -142,7 +142,7 @@ workiq mcp
 
 ## Platform Support
 
-The WorkIQ CLI and MCP Server is supported on `win_x64`, `win_arm64`, `linux_x64`, `linux_arm64`, `osx_x64` and `osx_arm64`. It is also supported in WSL as long as WSL is able to launch a browser to enable sign-in. 
+The WorkIQ CLI and MCP Server are supported on `win_x64`, `win_arm64`, `linux_x64`, `linux_arm64`, `osx_x64` and `osx_arm64`. It is also supported in WSL as long as WSL is able to launch a browser to enable sign-in. 
 
 One way to install browser support on WSL is with the following commands:
 
@@ -171,4 +171,4 @@ By using this package, you accept the license agreement. See [NOTICES.TXT](https
 
 ## Trademarks 
 
-This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft’s Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.
+This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft’s Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks/usage/general). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos is subject to those third-party's policies.


### PR DESCRIPTION
## Summary
- Add missing space after period in consent section
- Fix article "a MCP" to "an MCP" (MCP starts with vowel sound)
- Fix subject-verb agreement "CLI and MCP Server is" to "are"
- Fix subject-verb agreement "Any use...are" to "is"

## Test plan
- [x] Verified all changes are grammatically correct