### PR TITLE
Add server.json for MCP Registry publication

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.microsoft/workiq",
+  "title": "Microsoft Work IQ",
+  "description": "Query Microsoft 365 Copilot for workplace intelligence - emails, meetings, documents, Teams messages, and people information.",
+  "repository": {
+    "url": "https://github.com/microsoft/work-iq-mcp",
+    "source": "github"
+  },
+  "version": "0.2.8",
+  "websiteUrl": "https://github.com/microsoft/work-iq-mcp",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "@microsoft/workiq",
+      "version": "0.2.8",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "value": "mcp",
+          "type": "positional"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds the server.json file required to publish the WorkIQ MCP server to the official MCP Registry.

## Background

Per discussion with Toby Padilla, WorkIQ needs to be published to the OSS MCP Registry before it can be added to GitHub's MCP registry. The core requirement is a server.json file in the GitHub repo.

## References

- MCP Registry Quickstart: https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx
- Azure MCP Server example: https://registry.modelcontextprotocol.io/v0.1/servers/com.microsoft%2Fazure/versions/2.0.0-beta.13

## Changes

- Added server.json with metadata for @microsoft/workiq npm package (v0.2.8)
- Configured for stdio transport with 'mcp' command argument
- Uses com.microsoft/workiq namespace

## Next Steps

After merge:
1. Publish to MCP Registry using mcp-publisher CLI
2. Request allowlisting from GitHub team (Toby Padilla)