### PR TITLE
Add AgentAudit security badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 > Query your Microsoft 365 data with natural language — emails, meetings, documents, Teams messages, and more.
 
+[![AgentAudit Security](https://agentaudit.dev/api/badge/microsoft-work-iq-mcp)](https://agentaudit.dev/packages/microsoft-work-iq-mcp)
 [![npm version](https://img.shields.io/npm/v/@microsoft/workiq)](https://www.npmjs.com/package/@microsoft/workiq)
 
 The WorkIQ CLI and MCP (Model Context Protocol) server connects AI assistants to your Microsoft 365 Copilot data. Ask questions like *"What did my manager say about the project deadline?"* or *"Find my recent documents about Q4 planning."*


### PR DESCRIPTION
## Summary

Adds an [AgentAudit](https://agentaudit.dev) security badge to the README, showing the current trust score for the `microsoft-work-iq-mcp` package.

**Current Trust Score: 100/100** — No security findings detected across multiple independent AI-powered audits.

[![AgentAudit Security](https://agentaudit.dev/api/badge/microsoft-work-iq-mcp)](https://agentaudit.dev/packages/microsoft-work-iq-mcp)

## What is AgentAudit?

[AgentAudit](https://agentaudit.dev) is an open security registry for AI agent packages (MCP servers, skills, npm/pip packages). It provides:

- Multi-model security audits (Claude, GPT-4o, Gemini, etc.)
- Consensus-based trust scoring
- Standardized vulnerability IDs (ASF-IDs)

The badge auto-updates as new audits are submitted. Full audit details: https://agentaudit.dev/packages/microsoft-work-iq-mcp