### PR TITLE
Revise WorkIQ installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@ The fastest way to get started is with GitHub Copilot CLI:
 # 1. Open GitHub Copilot CLI
 copilot
 
-# 2. Add the plugins marketplace (one-time setup)
-/plugin marketplace add github/copilot-plugins
-
-# 3. Install WorkIQ
+# 2. Install WorkIQ
 /plugin install workiq@copilot-plugins
 ```
 


### PR DESCRIPTION
Updated installation instructions for WorkIQ in README as the copilot-plugins marketplace is now default in Copilot CLI