### PR TITLE
fix: use plugin-root-relative skill paths for Claude Code

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,1 +1,49 @@
-../.github/plugin/marketplace.json
+{
+  "name": "work-iq",
+  "metadata": {
+    "version": "1.0.0",
+    "description": "The official Microsoft Work IQ plugin collection"
+  },
+  "owner": {
+    "name": "Microsoft"
+  },
+  "plugins": [
+    {
+      "name": "workiq",
+      "source": "./plugins/workiq",
+      "version": "1.0.0",
+      "description": "Query Microsoft 365 data with natural language — emails, meetings, documents, Teams messages, and more.",
+      "skills": [
+        "./skills/workiq"
+      ]
+    },
+    {
+      "name": "microsoft-365-agents-toolkit",
+      "source": "./plugins/microsoft-365-agents-toolkit",
+      "version": "1.0.0",
+      "description": "Toolkit for building Microsoft 365 Copilot declarative agents — scaffolding, JSON manifest development, and capability configuration.",
+      "skills": [
+        "./skills/install-atk",
+        "./skills/declarative-agent-developer",
+        "./skills/ui-widget-developer"
+      ]
+    },
+    {
+      "name": "workiq-productivity",
+      "source": "./plugins/workiq-productivity",
+      "version": "1.0.0",
+      "description": "WorkIQ productivity skills powered by the local WorkIQ CLI — read-only insights across email, meetings, calendar, Teams, SharePoint, projects, and people.",
+      "skills": [
+        "./skills/action-item-extractor",
+        "./skills/daily-outlook-triage",
+        "./skills/email-analytics",
+        "./skills/meeting-cost-calculator",
+        "./skills/org-chart",
+        "./skills/multi-plan-search",
+        "./skills/site-explorer",
+        "./skills/channel-audit",
+        "./skills/channel-digest"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Replace the `.claude-plugin/marketplace.json` symlink (pointing to `.github/plugin/marketplace.json`) with a dedicated file that uses **plugin-root-relative** skill paths
- Fixes all skills failing to load in Claude Code with `Path not found` errors

## Problem

GitHub Copilot and Claude Code resolve `skills` paths in `marketplace.json` differently:

| | **GitHub Copilot** | **Claude Code** |
|---|---|---|
| Manifest location | `.github/plugin/marketplace.json` | `.claude-plugin/marketplace.json` |
| Skills path resolution | Relative to **repository root** | Relative to **plugin source directory** |

The current `.claude-plugin/marketplace.json` is a symlink to `.github/plugin/marketplace.json`, which uses repo-root-relative paths like:

```json
"source": "./plugins/workiq-productivity",
"skills": ["./plugins/workiq-productivity/skills/action-item-extractor"]
```

When Claude Code installs a plugin, it copies only the plugin's `source` directory into a local cache, then resolves skill paths relative to that cache root. The `plugins/workiq-productivity/` prefix has already been consumed during the copy, so paths like `./plugins/workiq-productivity/skills/...` don't exist in the cache — resulting in `Path not found` errors for all 9 skills across all 3 plugins.

## Fix

Replace the symlink with a standalone `marketplace.json` that uses plugin-root-relative paths per the [Claude Code plugin marketplace spec](https://code.claude.com/docs/en/plugin-marketplaces):

```json
"source": "./plugins/workiq-productivity",
"skills": ["./skills/action-item-extractor"]
```

The `.github/plugin/marketplace.json` (for Copilot) remains unchanged.

## Test plan

- [ ] Install `workiq-productivity` plugin in Claude Code — verify all 9 skills load without `Path not found` errors
- [ ] Install `workiq` plugin in Claude Code — verify skill loads correctly  
- [ ] Install `microsoft-365-agents-toolkit` plugin in Claude Code — verify all 3 skills load correctly
- [ ] Verify Copilot plugins still work via `.github/plugin/marketplace.json` (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)