### PR TITLE
fix: trim skill descriptions to stay under 1024 char limit

### DIFF
--- a/plugins/microsoft-365-agents-toolkit/.github/plugin/plugin.json
+++ b/plugins/microsoft-365-agents-toolkit/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "microsoft-365-agents-toolkit",
   "description": "Toolkit for building Microsoft 365 Copilot declarative agents — scaffolding, JSON manifest development, and capability configuration.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": {
     "name": "Microsoft"
   }

--- a/plugins/microsoft-365-agents-toolkit/skills/declarative-agent-developer/SKILL.md
+++ b/plugins/microsoft-365-agents-toolkit/skills/declarative-agent-developer/SKILL.md
@@ -5,16 +5,12 @@ description: >
   USE THIS SKILL for ANY task involving a declarative agent — including localization,
   scaffolding, editing manifests, adding capabilities, and deploying.
   Localization requires tokenized manifests and language files that only this skill knows how to produce.
-  Trigger phrases include "create agent", "create a declarative agent", "new declarative agent",
-  "scaffold an agent", "new agent project", "make a copilot agent",
-  "add a capability", "add a plugin", "configure my agent", "deploy my agent",
-  "fix my agent manifest", "edit my agent", "modify my agent",
-  "localize this agent", "localize my agent", "add localization",
-  "translate my agent", "add a language", "multi-language agent",
-  "add an API plugin", "add an MCP plugin", "add OAuth to my plugin", "add logo to my agent",
-  "review instructions", "improve instructions", "audit instructions",
-  "my agent doesn't work well", "agent gives generic answers",
-  "agent doesn't use the right tool", "fix my instructions"
+  Triggers: "create agent", "create a declarative agent", "new declarative agent",
+  "scaffold an agent", "new agent project", "add a capability", "add a plugin",
+  "configure my agent", "deploy my agent", "fix my agent manifest", "edit my agent",
+  "localize my agent", "add localization", "translate my agent", "multi-language agent",
+  "add an API plugin", "add an MCP plugin", "add OAuth to my plugin",
+  "review instructions", "improve instructions", "fix my instructions"
 ---
 
 # M365 Agent Developer

--- a/plugins/microsoft-365-agents-toolkit/skills/ui-widget-developer/SKILL.md
+++ b/plugins/microsoft-365-agents-toolkit/skills/ui-widget-developer/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-widget-developer
 description: |
-  Build MCP (Model Context Protocol) servers for Copilot Chat using the OpenAI Apps SDK or MCP Apps SDK widget rendering support (any language). Use this skill when:
+  Build MCP servers for Copilot Chat using the OpenAI Apps SDK or MCP Apps SDK widget rendering support (any language). Use this skill when:
   - Creating MCP servers that integrate with M365 Copilot declarative agents
   - Building rich interactive widgets (HTML) that render in Copilot Chat
   - Implementing tools that return structuredContent for widget rendering
@@ -9,7 +9,7 @@ description: |
   - Setting up devtunnels for localhost MCP server exposure
   - Configuring mcpPlugin.json manifests with RemoteMCPServer runtime
   Do NOT use this skill for general agent development (scaffolding, manifests, deployment) — use declarative-agent-developer instead. This skill is ONLY for MCP server + widget development.
-  Triggers: "MCP server for Copilot", "OpenAI Apps SDK", "Copilot widget", "structuredContent", "MCP plugin", "devtunnels MCP", "bizchat MCP", "OAI app", "widget rendering", "text/html+skybridge", "UI widget"
+  Triggers: "MCP server for Copilot", "OpenAI Apps SDK", "Copilot widget", "structuredContent", "MCP plugin", "devtunnels MCP", "OAI app", "widget rendering", "UI widget"
 ---
 
 # Copilot MCP Server Development


### PR DESCRIPTION
Removed duplicate/redundant trigger phrases from skill descriptions:
- **declarative-agent-developer**: 941 → 804 chars
- **ui-widget-developer**: 973 → 910 chars

Both now well under the 1024 character limit.