### PR TITLE
Add missing workiq-preview plugin to claude marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,6 +18,15 @@
       ]
     },
     {
+      "name": "workiq-preview",
+      "source": "./plugins/workiq-preview",
+      "version": "0.5.0",
+      "description": "Query Microsoft 365 data with natural language — emails, meetings, documents, Teams messages, and more.",
+      "skills": [
+        "./skills/workiq-preview"
+      ]
+    },
+    {
       "name": "microsoft-365-agents-toolkit",
       "source": "./plugins/microsoft-365-agents-toolkit",
       "version": "1.3.1",


### PR DESCRIPTION
The .claude-plugin/marketplace.json was missing the workiq-preview plugin entry that exists in .github/plugin/marketplace.json.