### PR TITLE
workiq-preview: follow-up doc fixes from PR #127 review (14 items)

### DIFF
--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -21,7 +21,7 @@
       "name": "workiq-preview",
       "source": "./plugins/workiq-preview",
       "version": "0.5.0",
-      "description": "Query Microsoft 365 data with natural language — emails, meetings, documents, Teams messages, and more.",
+      "description": "Preview build: full WorkIQ tool surface — agentic queries via ask_work_iq plus direct reads and writes (create, update, delete, send, upload) across emails, meetings, calendar, documents, Teams, OneDrive, and SharePoint.",
       "skills": [
         "./plugins/workiq-preview/skills/workiq-preview"
       ]

--- a/plugins/workiq-preview/.github/plugin/plugin.json
+++ b/plugins/workiq-preview/.github/plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "workiq-preview",
-  "description": "Query Microsoft 365 data with natural language — emails, meetings, documents, Teams messages, and more.",
+  "description": "Preview build: full WorkIQ tool surface — agentic queries via ask_work_iq plus direct reads and writes (create, update, delete, send, upload) across emails, meetings, calendar, documents, Teams, OneDrive, and SharePoint.",
   "version": "0.5.0",
   "author": {
     "name": "Microsoft"

--- a/plugins/workiq-preview/README.md
+++ b/plugins/workiq-preview/README.md
@@ -1,6 +1,6 @@
-# Work IQ Plugin
+# Work IQ Plugin — Preview
 
-> Query Microsoft 365 data with natural language — emails, meetings, documents, Teams messages, and more.
+> **Preview build.** Full WorkIQ tool surface for GitHub Copilot CLI: agentic semantic queries via `ask_work_iq` **plus** direct, structured reads and writes against Microsoft 365 — emails, meetings, calendar, documents, Teams messages, OneDrive/SharePoint files, and people.
 
 ## Installation
 
@@ -26,11 +26,13 @@ Add to your `.mcp.json` or IDE MCP settings:
 
 ## Updating
 
-If you installed WorkIQ globally with npm, run the following command to update to the latest version:
+If you installed WorkIQ globally with npm, run the following command to install or update to the latest preview build:
 
 ```bash
-npm update -g @microsoft/workiq@preview
+npm install -g @microsoft/workiq@preview
 ```
+
+> **Note:** `npm update` ignores dist-tag specifiers, so it will not switch you to the preview channel. Use `npm install` as shown above.
 
 To verify the installed version after updating:
 
@@ -42,31 +44,53 @@ workiq version
 
 ## Usage
 
+The preview plugin exposes the full WorkIQ tool surface — read **and** write — via 11 MCP tools.
+
+### Semantic queries (`ask_work_iq`)
+
 ```
-# Emails
 "What did John say about the proposal?"
 "Summarize emails from the leadership team this week"
-
-# Meetings
-"What's on my calendar tomorrow?"
-"What are my upcoming meetings this week?"
-
-# Documents
-"Find my recent PowerPoint presentations"
-"Find documents I worked on yesterday"
-
-# Teams
-"Summarize today's messages in the Engineering channel"
-
-# People
+"What's top of mind for Sarah?"
+"Find the design doc for the authentication system"
 "Who is working on Project Alpha?"
 ```
+
+### Structured reads (`fetch_work_iq`, `search_paths_work_iq`, `get_schema_work_iq`, `fetch_blob_work_iq`)
+
+```
+"List my unread emails from Sarah this week"
+"What meetings do I have Monday?"
+"Show me the channels in the DevX team"
+"List files in my OneDrive 'Specs' folder"
+"Who are Rob's direct reports?"
+"Download the latest PowerPoint from my OneDrive 'Specs' folder"
+```
+
+### Writes (`create_entity_work_iq`, `update_entity_work_iq`, `delete_entity_work_iq`, `do_action_work_iq`, `upload_blob_work_iq`)
+
+> ⚠️ Writes execute immediately and are visible to other people or unrecoverable. The skill is instructed to confirm with you before sending mail, forwarding, accepting/declining meetings, or permanently deleting.
+
+```
+"Send the draft email to the engineering distribution list"
+"Create a calendar event Friday at 3pm with the design team"
+"Accept the 2pm meeting from Rob"
+"Decline the Monday standup — I'll catch up on the recording"
+"Mark Sarah's last three emails as read"
+"Reply to the deadline thread with 'on track for Friday'"
+"Upload report.pdf to my OneDrive root"
+"Move the design review thread to the Archive folder"
+```
+
+### CLI commands (out-of-band of the MCP server)
+
+Some operations are not exposed as MCP tools and must be run as shell commands — `auth login`/`logout`, `auth consent` (granting additional Graph scopes), `config show`/`set`/`reset`, `version`. Invoke them via `npx -y @microsoft/workiq@preview <command>` to guarantee you hit the same binary the MCP server uses. See [`skills/workiq-preview/references/cli-commands.md`](./skills/workiq-preview/references/cli-commands.md) for the full reference.
 
 ## Skills
 
 | Skill | Description |
 |-------|-------------|
-| [**workiq-preview**](./skills/workiq-preview/SKILL.md) | Query M365 Copilot for workplace intelligence |
+| [**workiq-preview**](./skills/workiq-preview/SKILL.md) | Guides usage of the full WorkIQ tool surface — `ask_work_iq` for semantic questions plus entity tools for fast, structured M365 reads and writes |
 
 ## Platform Support
 

--- a/plugins/workiq-preview/skills/workiq-preview/SKILL.md
+++ b/plugins/workiq-preview/skills/workiq-preview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workiq-preview
-description: Query Microsoft 365 Copilot for workplace intelligence - emails, meetings, documents, Teams messages, and people information. USE THIS SKILL for ANY workplace-related question where the answer likely exists in Microsoft 365 data. This includes questions about what someone said, shared, or communicated; meetings, emails, messages, or documents; priorities, decisions, or context from colleagues; organizational knowledge; project status; team activities; or any information that would be in Outlook, Teams, SharePoint, OneDrive, or Calendar. When in doubt about workplace context, try WorkIQ first. Trigger phrases include "what did [person] say", "what are [person]'s priorities", "top of mind from [person]", "what was discussed", "find emails about", "what meetings", "what documents", "who is working on", "what's the status of", "any updates on", etc.
+description: Preview build of WorkIQ — the full Microsoft 365 tool surface: agentic semantic queries via ask_work_iq PLUS direct, structured reads and writes for emails, meetings, calendar, documents, Teams messages, OneDrive/SharePoint files, and people. USE THIS SKILL for ANY workplace question or write action where the data lives in Microsoft 365. Read triggers, "what did [person] say", "what are [person]'s priorities", "top of mind from [person]", "what was discussed", "find emails about", "what meetings do I have", "what documents", "who is working on", "what's the status of", "any updates on". Write triggers, "send email", "reply to [thread]", "forward to", "create a calendar event", "schedule a meeting", "accept/decline the meeting", "mark as read", "delete the draft", "upload to OneDrive", "download attachment". When in doubt about workplace context, try WorkIQ first.
 compatibility: >
   Requires Node.js 18+ and npm (provides `npx`, used to launch the
   @microsoft/workiq MCP server). If missing, see
@@ -143,20 +143,40 @@ Entity tools provide **fast, direct access to specific M365 data** via Work IQ A
 
 All URL parameters (`entityUrls`, `parentUrl`, `entityUrl`, `actionUrl`, `functionUrl`, `blobUrl`, `targetUrl`) **must**:
 
-1. **Omit any scheme, authority, and API version prefix** — start with `/me/...` or `/users/...`, never include a full `https://...` URL or a `/v1.0/...` prefix
-   - ❌ `https://example.com/v1.0/me/messages`
+1. **Server-relative path only** — start with `/` and **omit** any scheme, authority, or API-version prefix. Valid path roots include `/me/...`, `/users/...`, `/teams/...`, `/groups/...`, `/sites/...`, `/drives/...`, `/planner/...`, and others — anything Graph exposes.
+   - ❌ `https://graph.microsoft.com/v1.0/me/messages`
    - ❌ `/v1.0/me/messages`
    - ✅ `/me/messages`
+   - ✅ `/teams/{teamId}/channels`
 2. **URL-encode all query parameter values** — spaces become `%20`, quotes become `%27`, etc.
    - ❌ `$orderby=receivedDateTime desc`
    - ✅ `$orderby=receivedDateTime%20desc`
+   - **Exception:** OData property paths (the `/` separator between navigation properties, e.g. `start/dateTime`, `from/emailAddress/address`) are **not** encoded. The `/` only gets encoded when it appears inside a string literal value.
+
+### ⚠️ `jsonBody` Format Rules (write tools)
+
+`create_entity_work_iq`, `update_entity_work_iq`, `do_action_work_iq`, and `call_function_work_iq` accept a `jsonBody` parameter. **`jsonBody` is a string** containing JSON, **not** a JSON object — the value must be a JSON-encoded string with quotes escaped.
+
+- ❌ `"jsonBody": { "subject": "Hello" }` — object, rejected by schema
+- ❌ `"jsonBody": "{"subject":"Hello"}"` — broken quoting
+- ✅ `"jsonBody": "{\"subject\":\"Hello\"}"` — JSON-encoded string
+
+If a write tool returns a schema error mentioning `jsonBody` type, this is almost certainly the cause. Re-serialize the body and retry.
+
+### ⚠️ Placeholders in examples are not literals
+
+Reference examples use `{id}`, `{listId}`, `{teamId}`, `{taskId}`, `{driveId}`, `{messageId}`, etc. as placeholders for IDs you obtained from a prior call. **Do not call a URL with `{id}` literal in it** — replace it with the actual ID first (typically from `fetch_work_iq` or `create_entity_work_iq`). A literal `/me/messages/{id}` will return 404 / "resource not found".
+
+### ⚠️ Write actions execute immediately — confirm with the user first
+
+`do_action_work_iq` (especially `/me/sendMail`, `/forward`, `/accept`, `/decline`, `/permanentDelete`) and write-side `create_entity_work_iq` / `update_entity_work_iq` / `delete_entity_work_iq` calls take effect immediately and are visible to other people (recipients, meeting organizers) or unrecoverable. **Before invoking any write tool, summarize what you're about to do and get the user's confirmation.** This is especially important for sendMail, forward, decline, and permanentDelete.
 
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
 | `search_paths_work_iq` | Discover available API paths | `filter` (regex), `backend` |
 | `get_schema_work_iq` | Inspect fields and body shape for a path | `path`, `httpMethod`, `apiVersion` |
 | `fetch_work_iq` | Fetch entities by path (GET) | `entityUrls[]` — supports OData (`$filter`, `$select`, `$top`) |
-| `call_function_work_iq` | Call named functions (delta, getSchedule, reminderView) | `functionUrl` with inline function params |
+| `call_function_work_iq` | Call named OData functions — GET-shaped, side-effect-free, parenthesised inline params (e.g. `delta`, `reminderView`) | `functionUrl` with inline function params |
 | `create_entity_work_iq` | Create a new entity (POST to collection) | `parentUrl`, `jsonBody` |
 | `update_entity_work_iq` | Update fields on an existing entity (PATCH) | `entityUrl` with ID, `jsonBody` |
 | `delete_entity_work_iq` | Delete an entity (DELETE) | `entityUrl` with ID |
@@ -169,7 +189,7 @@ Read the relevant reference file for full parameter details and examples:
 - `references/search-paths-work-iq.md` — if you need to discover what paths are available
 - `references/get-schema-work-iq.md` — if you need to understand an entity's fields before reading or writing
 - `references/fetch-work-iq.md` — if you need to fetch structured or filtered M365 data
-- `references/call-function-work-iq.md` — if the path uses function call syntax (e.g., `getSchedule`)
+- `references/call-function-work-iq.md` — if the path uses OData function call syntax (e.g., `reminderView(...)`, `delta`)
 - `references/create-entity-work-iq.md` — if you need to create a new calendar event, email draft, task, etc.
 - `references/update-entity-work-iq.md` — if you need to update fields on an existing entity
 - `references/delete-entity-work-iq.md` — if you need to delete an entity

--- a/plugins/workiq-preview/skills/workiq-preview/references/call-function-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/call-function-work-iq.md
@@ -1,20 +1,21 @@
 # call_function_work_iq
 
-Call a WorkIQ Graph function via HTTP GET. Graph functions are named operations that return computed results rather than stored entities — for example, `delta` (change tracking), `reminderView` (upcoming reminders), or `getSchedule` (free/busy availability).
+Call an OData function via HTTP GET. Functions are **side-effect-free** named operations that return computed results — for example, `delta` (change tracking on a collection) or `reminderView` (computed list of upcoming reminders).
+
+**Use this tool only for true GET-shaped OData functions.** If the operation is invoked with a request body (e.g. `getSchedule`, `findMeetingTimes`, `sendMail`), it's an **action**, not a function — use `do_action_work_iq` instead, even when the path looks function-like.
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `functionUrl` | string | Yes | The function path including any required inline parameters (e.g., `/me/reminderView(startDateTime='...',endDateTime='...')`). Must be relative to the domain root — start with `/`, do not include a scheme or authority (`https://graph.microsoft.com` ❌, `/me/reminderView(...)` ✅). URL-encode any special characters in inline parameter values. |
+| `functionUrl` | string | Yes | The function path including any required inline parameters (e.g., `/me/reminderView(startDateTime='...',endDateTime='...')`). Must be a server-relative path — start with `/`, no scheme or authority (`https://graph.microsoft.com` ❌, `/me/reminderView(...)` ✅). URL-encode any special characters in inline parameter values. |
 
 ## When to Use
 
-- When you need free/busy availability for scheduling (`getSchedule`)
-- When you need upcoming meeting reminders (`reminderView`)
-- Any time a Graph path requires function call syntax `functionName(param=value)`
+- When you need a computed result that takes no request body (`delta`, `reminderView`)
+- Any time the OData path uses function call syntax `functionName(param=value)` and the operation is documented as GET
 
-Distinguish from `fetch_work_iq`: use `call_function_work_iq` when the path includes a function invocation with inline parameters. Use `fetch_work_iq` for plain collection or item paths.
+If you're not sure whether something is a function or an action, run `get_schema_work_iq` on the path with `httpMethod: "get"` first. If no GET schema is returned but POST is, route to `do_action_work_iq`.
 
 ## Examples
 
@@ -23,9 +24,8 @@ Distinguish from `fetch_work_iq`: use `call_function_work_iq` when the path incl
 { "functionUrl": "/me/reminderView(startDateTime='2024-06-01T00:00:00Z',endDateTime='2024-06-30T23:59:59Z')" }
 ```
 
-### Get free/busy schedule for multiple users
+### Track changes to a mail folder (delta query)
 ```json
-{ "functionUrl": "/me/calendar/getSchedule" }
+{ "functionUrl": "/me/mailFolders/inbox/messages/delta" }
 ```
-
 

--- a/plugins/workiq-preview/skills/workiq-preview/references/create-entity-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/create-entity-work-iq.md
@@ -2,6 +2,8 @@
 
 Create a new WorkIQ entity by POSTing to a collection path. Use this to create calendar events, draft emails, tasks, Teams messages, and other M365 resources.
 
+> **⚠️ Writes are persistent.** Creating a calendar event sends invitations to attendees; creating a draft email is invisible until sent but takes up space; creating a task or message in a shared list is visible to collaborators. **Before invoking, summarize what you're about to create (subject, attendees, due date, parent list/folder) and get the user's explicit confirmation.**
+
 ## Parameters
 
 | Parameter | Type | Required | Description |
@@ -46,13 +48,5 @@ Create a new WorkIQ entity by POSTing to a collection path. Use this to create c
 {
   "parentUrl": "/me/todo/lists/{listId}/tasks",
   "jsonBody": "{\"title\":\"Review pull request\",\"dueDateTime\":{\"dateTime\":\"2024-06-05T17:00:00\",\"timeZone\":\"UTC\"}}"
-}
-```
-
-### Create a reply to a message
-```json
-{
-  "parentUrl": "/me/messages/{id}/reply",
-  "jsonBody": "{\"comment\":\"Thanks for the update!\"}"
 }
 ```

--- a/plugins/workiq-preview/skills/workiq-preview/references/do-action-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/do-action-work-iq.md
@@ -1,6 +1,8 @@
 # do_action_work_iq
 
-Execute a WorkIQ action via HTTP POST. Actions are named operations that perform a task (rather than creating a resource) — such as sending an email, copying a file, moving a message, or accepting a meeting invitation.
+Execute a WorkIQ action via HTTP POST. Actions are named operations that perform a task (rather than creating a resource) — such as sending an email, copying a file, moving a message, accepting a meeting invitation, or computing free/busy availability across multiple calendars.
+
+> **⚠️ Write actions execute immediately.** `/me/sendMail`, `/forward`, `/accept`, `/decline`, `/permanentDelete`, and similar verbs take effect right away and are visible to other people or unrecoverable. **Before invoking, summarize the action (recipients, subject, body, target ID) and get the user's explicit confirmation.** Do not auto-send drafts or auto-respond to meeting invites without confirmation.
 
 ## Parameters
 
@@ -15,9 +17,12 @@ Execute a WorkIQ action via HTTP POST. Actions are named operations that perform
 - Accepting, declining, or tentatively accepting a meeting invitation
 - Copying or moving a message to another folder
 - Forwarding a message
+- Replying to a message
+- Computing free/busy availability for multiple users (`getSchedule`)
+- Initiating a large file upload session (`createUploadSession`)
 - Subscribing to change notifications
 
-Distinguish from `create_entity_work_iq`: use `do_action_work_iq` for verbs (send, copy, move, accept) rather than creating a new stored resource.
+Distinguish from `create_entity_work_iq`: use `do_action_work_iq` for verbs (send, copy, move, accept, reply, getSchedule) rather than creating a new stored resource. If an operation has a function-like name (`getSchedule`, `findMeetingTimes`) but takes a JSON body, it's still an action — POST it through this tool.
 
 ## Examples
 
@@ -81,3 +86,23 @@ Distinguish from `create_entity_work_iq`: use `do_action_work_iq` for verbs (sen
   "jsonBody": "{\"comment\":\"Thanks for the update!\"}"
 }
 ```
+
+### Get free/busy availability for multiple users (`getSchedule`)
+```json
+{
+  "actionUrl": "/me/calendar/getSchedule",
+  "jsonBody": "{\"schedules\":[\"adelev@contoso.com\",\"meganb@contoso.com\"],\"startTime\":{\"dateTime\":\"2024-06-03T09:00:00\",\"timeZone\":\"Pacific Standard Time\"},\"endTime\":{\"dateTime\":\"2024-06-03T18:00:00\",\"timeZone\":\"Pacific Standard Time\"},\"availabilityViewInterval\":60}"
+}
+```
+
+`availabilityViewInterval` is optional minutes (default 30, min 5, max 1440). `schedules` is a string array of SMTP addresses (users, distribution lists, rooms, or equipment).
+
+### Initiate a large file upload session
+```json
+{
+  "actionUrl": "/me/drive/root:/Projects/big-file.zip:/createUploadSession",
+  "jsonBody": "{\"item\":{\"@microsoft.graph.conflictBehavior\":\"replace\"}}"
+}
+```
+
+The response returns an `uploadUrl` you can PUT chunks to. Use this for files larger than 4MB (`upload_blob_work_iq`'s simple PUT limit).

--- a/plugins/workiq-preview/skills/workiq-preview/references/fetch-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/fetch-work-iq.md
@@ -33,10 +33,13 @@ Common URL encodings for OData query values:
 | `(` | `%28` | `$filter=startsWith%28subject%2C%27Re%3A%27%29` |
 | `)` | `%29` | (same as above) |
 | `:` | `%3A` | (in string literals) |
-| `/` (in values) | `%2F` | `$orderby=receivedDateTime%20desc` |
-| `,` (in values) | `%2C` | (in string literals) |
+| `/` *(only inside string-literal values)* | `%2F` | (e.g. inside a quoted `$filter` value) |
+| `,` *(only inside string-literal values)* | `%2C` | (in string literals; **not** in `$select=a,b,c` lists) |
 
-> **Tip:** OData keywords and property paths (like `$filter=`, `isRead`, `eq`) use standard ASCII and do not need encoding. Only encode the *values* and string literals within query parameters.
+> **Important — what NOT to encode:**
+> - OData **property paths** like `start/dateTime`, `from/emailAddress/address`: leave the `/` raw. Use `$orderby=start/dateTime`, never `$orderby=start%2FdateTime`.
+> - **Comma-separated `$select` lists** like `$select=subject,from,receivedDateTime`: leave the `,` raw. Only encode commas that appear inside a quoted value.
+> - OData keywords and field names (`$filter=`, `isRead`, `eq`, `desc`): standard ASCII, no encoding needed.
 
 ## OData Query Tips
 
@@ -62,7 +65,7 @@ Common URL encodings for OData query values:
 
 ### Get upcoming calendar events
 ```json
-{ "entityUrls": ["/me/events?$top=5&$orderby=start%2FdateTime&$select=subject,start,end,location"] }
+{ "entityUrls": ["/me/events?$top=5&$orderby=start/dateTime&$select=subject,start,end,location"] }
 ```
 
 ### Get a specific message by ID

--- a/plugins/workiq-preview/skills/workiq-preview/references/install-prerequisites.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/install-prerequisites.md
@@ -7,7 +7,7 @@ The WorkIQ MCP server is distributed as the npm package `@microsoft/workiq` and 
 
 To verify what's installed:
 
-```powershell
+```bash
 node --version
 npm --version
 npx --version
@@ -49,7 +49,7 @@ Download and run the Windows installer (`.msi`) from <https://nodejs.org/en/down
 
 ### Option A — Homebrew (recommended)
 
-```powershell
+```bash
 brew install node
 ```
 
@@ -59,7 +59,7 @@ Download and run the macOS installer (`.pkg`) from <https://nodejs.org/en/downlo
 
 ### Option C — nvm (if you manage multiple Node versions)
 
-```powershell
+```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 # Then in a new shell:
 nvm install --lts
@@ -72,32 +72,32 @@ nvm use --lts
 
 ### Debian / Ubuntu
 
-```powershell
+```bash
 curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
 sudo apt-get install -y nodejs
 ```
 
 ### Fedora / RHEL / CentOS Stream
 
-```powershell
+```bash
 sudo dnf install -y nodejs npm
 ```
 
 ### Arch / Manjaro
 
-```powershell
+```bash
 sudo pacman -S --noconfirm nodejs npm
 ```
 
 ### Alpine
 
-```powershell
+```bash
 sudo apk add --no-cache nodejs npm
 ```
 
 ### Any distro — nvm (per-user, no sudo)
 
-```powershell
+```bash
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
 # Then in a new shell:
 nvm install --lts
@@ -110,11 +110,11 @@ nvm use --lts
 
 [Volta](https://volta.sh) installs and pins Node.js per project and works the same on Windows, macOS, and Linux.
 
-```powershell
+```bash
 # macOS / Linux
 curl https://get.volta.sh | bash
 
-# Windows
+# Windows (PowerShell)
 winget install Volta.Volta
 
 # Then in a new shell:

--- a/plugins/workiq-preview/skills/workiq-preview/references/troubleshooting.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/troubleshooting.md
@@ -48,7 +48,7 @@ copilot plugin install workiq@microsoft
 
 **Fix:**
 
-1. Decide which channel (stable or preview) you want to use, and uninstall the others (see the "Multiple WorkIQ plugins installed" section above).
+1. Decide which channel (stable or preview) you want to use, and uninstall the others (see the "Both `workiq` and `workiq-preview` installed side-by-side" section above).
 2. If you have a globally installed `workiq` (`npm ls -g @microsoft/workiq`), make sure its version matches the one the MCP server runs (`@latest` for stable, `@preview` for preview).
 3. If config looks corrupted or out of sync, reset it and re-consent:
 

--- a/plugins/workiq-preview/skills/workiq-preview/references/upload-blob-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/upload-blob-work-iq.md
@@ -26,7 +26,7 @@ Upload a local file to a WorkIQ path via HTTP PUT. Use this to upload files to O
 
 ## Gotchas
 
-- **File size limit**: Simple PUT uploads work for files up to 4MB. For larger files, use the Graph large file upload session pattern (not currently supported directly — use `create_entity_work_iq` to initiate an upload session).
+- **File size limit**: Simple PUT uploads via this tool work for files up to 4MB. For larger files, initiate an upload session via `do_action_work_iq` with `actionUrl: "/me/drive/root:/{path}:/createUploadSession"` and PUT chunks to the returned `uploadUrl`. See the `createUploadSession` example in `do-action-work-iq.md`.
 - The URL uses the Graph path-based format `root:/{path}:/content` — include the leading `/` before the filename.
 
 ## Examples


### PR DESCRIPTION
# workiq-preview: follow-up doc fixes from PR #127 review

Surgical doc-only follow-up to the [`workiq-preview` plugin](https://github.com/microsoft/work-iq/pull/127) that landed in #127. Three independent reviewers (one internal adversarial pass, two external) flagged the same set of correctness, LLM-consumption, and self-consistency issues; this PR addresses 14 of them. **No tool, schema, or runtime changes — docs and a couple of marketplace descriptions only.**

## Why this is needed

PR #127 added the full WorkIQ tool surface (`ask_work_iq` + 9 entity tools + 2 blob tools, including **writes** for the first time) as a side-by-side preview plugin. Skill prompting drives almost everything an LLM does with this surface, so a handful of small doc bugs translate directly into failed tool calls or unsafe behaviour at runtime. The fixes here are mechanical and low-risk.

---

## 🔴 Correctness fixes

### C1 — `getSchedule` was in the wrong reference file
`getSchedule` is a Graph **action** (POST with a body), not an OData function. Calling it via `call_function_work_iq` (HTTP GET, no body) returns 405 / 400.

- **Removed** from `references/call-function-work-iq.md`.
- **Added to `references/do-action-work-iq.md`** with the correct body shape: `{schedules, startTime, endTime, availabilityViewInterval}` using `dateTimeTimeZone` objects (sourced from Microsoft Graph docs).
- Both files now have a one-paragraph clarifier of function-vs-action semantics: `call_function_work_iq` is for true OData functions (parenthesised inline params, GET-able, side-effect-free); anything POST-shaped goes through `do_action_work_iq`.

### C2 — Duplicate `/messages/{id}/reply` example
The same example appeared in both `create-entity-work-iq.md` ("Create a reply") and `do-action-work-iq.md`. The SKILL.md selection rule routes verbs to `do_action_work_iq`, so the model would pick whichever doc it loaded first — inconsistent across runs. Removed from `create-entity-work-iq.md`.

### C6 — URL format rule was narrower than the docs themselves
SKILL.md item #1 of the URL Format Rules said paths must "start with `/me/...` or `/users/...`" — but the same docs use `/teams/`, `/planner/`, `/drives/`, `/sites/`, `/groups/` (all valid Graph roots). An LLM following the rule literally would reject its own examples.

Broadened to "**Server-relative path only** — start with `/`... Valid path roots include `/me/...`, `/users/...`, `/teams/...`, `/groups/...`, `/sites/...`, `/drives/...`, `/planner/...`, and others — anything Graph exposes." Added a `/teams/{teamId}/channels` ✅ example.

### C8 — `upload_blob_work_iq` pointed at the wrong tool for large files
`references/upload-blob-work-iq.md` said: *"For larger files… use `create_entity_work_iq` to initiate an upload session."* But `createUploadSession` is a Graph action (POST returning an `uploadUrl`), not an entity creation. Following this would POST to a collection URL and fail.

Fixed to direct users to `do_action_work_iq` with `actionUrl: "/me/drive/root:/{path}:/createUploadSession"`. The full POST-body shape and reply example now live in `do-action-work-iq.md`.

### C9 — `fetch-work-iq.md` over-encoded `/` in property paths
Example showed `$orderby=start%2FdateTime`. Graph property-path slashes (`start/dateTime`, `from/emailAddress/address`) are conventionally **not** percent-encoded; every Graph doc shows them raw. Encoding worked but diverged from every reference users see elsewhere.

- Unencoded the example: `$orderby=start/dateTime`.
- Expanded the encoding-rules table with explicit **"what NOT to encode"** notes for both `/` in property paths and `,` in `$select` lists.

### L4 — Wrong-URL example used `example.com` instead of `graph.microsoft.com`
SKILL.md showed `❌ https://example.com/v1.0/me/messages` while every other file used `graph.microsoft.com`. Unified to the real hostname so the LLM doesn't learn a placeholder is acceptable as the "bad case".

---

## 🟠 LLM-consumption fixes

### C3 / C4 / L7 — Description didn't distinguish preview from stable; no write triggers
The preview plugin's `description` field (in SKILL.md frontmatter, `marketplace.json`, and `plugin.json`) was a near-copy of stable `workiq`'s description — same read-only triggers, no mention of writes. Consequences:

1. A user browsing `copilot plugin marketplace list` couldn't tell the two entries apart.
2. The LLM had no signal to fire `workiq-preview` on write prompts ("send email", "create event", "accept meeting", etc.) — the description tells the model when to use the skill.

Rewrote the description in all three places:

- New framing: *"Preview build of WorkIQ — the full Microsoft 365 tool surface: agentic semantic queries via `ask_work_iq` PLUS direct, structured reads and writes…"*
- Added **Write triggers** alongside the existing **Read triggers**: *"send email", "reply to [thread]", "forward to", "create a calendar event", "schedule a meeting", "accept/decline the meeting", "mark as read", "delete the draft", "upload to OneDrive", "download attachment"*.
- Total length: **875 / 1024 chars** (under the runtime cap documented in `AGENTS.md`).

### L1 — `jsonBody` is a string, not an object (LLM footgun)
The biggest hidden footgun in the schema: `create_entity_work_iq`, `update_entity_work_iq`, `do_action_work_iq`, and `call_function_work_iq` all take `jsonBody` as a **JSON-encoded string**, not a JSON object. Schema rejection is silent about the cause.

Added a ⚠️ callout in SKILL.md with wrong-vs-right examples:

- ❌ `"jsonBody": { "subject": "Hello" }` — object, rejected
- ❌ `"jsonBody": "{"subject":"Hello"}"` — broken quoting
- ✅ `"jsonBody": "{\"subject\":\"Hello\"}"` — JSON-encoded string

Plus a recovery hint: *"If a write tool returns a schema error mentioning `jsonBody` type, this is almost certainly the cause."*

### L2 — Placeholders in examples are not literals
Reference examples use `{id}`, `{listId}`, `{teamId}`, `{taskId}`, `{driveId}`, `{messageId}` as placeholders. LLMs routinely paste these verbatim into tool calls, getting 404s.

Added a ⚠️ callout: *"Do not call a URL with `{id}` literal in it — replace it with the actual ID first (typically from `fetch_work_iq` or `create_entity_work_iq`). A literal `/me/messages/{id}` will return 404."*

---

## 🟡 Self-consistency / polish

### S2 — Broken cross-reference
`troubleshooting.md` referenced *"the 'Multiple WorkIQ plugins installed' section above"* — no such section exists. The actual heading is *"Both 'workiq' and 'workiq-preview' installed side-by-side"*. Fixed the link text to match.

### S4 — `npm update` ignores dist-tags
`plugins/workiq-preview/README.md` told users to update with `npm update -g @microsoft/workiq@preview`. **`npm update` ignores dist-tag specifiers** — running it on the preview channel will not switch you between channels, and may silently leave you on stable.

- Changed to `npm install -g @microsoft/workiq@preview`.
- Added a note explaining the gotcha so future readers don't reintroduce it.

### S7 — Every code fence in `install-prerequisites.md` was tagged `powershell`
…including `brew install node`, `sudo apt-get install`, `curl … | bash`, `nvm install --lts`. Functionally harmless but visually wrong (incorrect syntax highlighting) and confusing.

Retagged 9 fences `bash` for macOS/Linux; kept 3 `powershell` for genuinely Windows-only blocks (`winget`, `choco`, `scoop`).

### S8 — No write-safety guideline
`delete-entity-work-iq.md` correctly warns to "confirm the entity ID before deleting." The same care wasn't applied to send-mail, decline, forward, or move-to-folder — even though sending a wrong email is more user-visible and unrecoverable than deleting a draft.

Added a "writes execute immediately — confirm with the user first" callout in three places (echoing the same guidance so the LLM sees it regardless of which reference it loads):

- SKILL.md
- `references/do-action-work-iq.md`
- `references/create-entity-work-iq.md`

Explicitly singles out `/me/sendMail`, `/forward`, `/accept`, `/decline`, `/permanentDelete` as the highest-risk paths.

### S9 — README didn't reflect the headline feature (writes)
`plugins/workiq-preview/README.md` was a near-copy of the stable plugin's README — titled simply "Work IQ Plugin", and the example prompts only showed reads. Doesn't reflect what the preview actually adds.

Rewrote the README:

- Title: `Work IQ Plugin — Preview`; tagline calls out writes.
- New "Usage" section grouped by **tool category** matching the actual MCP surface:
  - **Semantic queries** (`ask_work_iq`) — 5 example prompts
  - **Structured reads** — 6 prompts across all read tools
  - **Writes** — 8 prompts (send, create event, accept/decline, mark read, reply, upload, move) with a ⚠️ confirmation note
- New "CLI commands (out-of-band of the MCP server)" subsection explaining that `auth login`, `auth consent`, `config show`/`set`/`reset`, `version` aren't MCP tools — and telling users to invoke them via `npx -y @microsoft/workiq@preview <cmd>` to avoid hitting a stale global `workiq` binary.

---

## Files changed

```
.github/plugin/marketplace.json                    |  2 +-
plugins/workiq-preview/.github/plugin/plugin.json  |  2 +-
plugins/workiq-preview/README.md                   | 56 +++++++++++++++-------
plugins/workiq-preview/skills/workiq-preview/SKILL.md
                                                   | 30 ++++++++++--
.../references/call-function-work-iq.md            | 18 +++----
.../references/create-entity-work-iq.md            | 10 +---
.../references/do-action-work-iq.md                | 29 ++++++++++-
.../references/fetch-work-iq.md                    | 11 +++--
.../references/install-prerequisites.md            | 20 ++++----
.../references/troubleshooting.md                  |  2 +-
.../references/upload-blob-work-iq.md              |  2 +-
11 files changed, 124 insertions(+), 58 deletions(-)
```

---

## Out of scope (deferred for separate follow-ups)

These items from the consolidated review aren't in this PR — most need either binary-side verification, larger structural additions, or author judgement calls:

- **C5** — `config` sub-command name mismatch (`show` vs `list`, existence of `unset`). Needs verification against the `0.5.0-preview2` binary.
- **C7** — First-run setup checklist (Node 18+, EULA, sign-in, admin consent, `experimental=true`, per-path Graph scopes) in SKILL.md. Larger structural addition; deserves its own PR.
- **S1** — Normalize every `workiq` shell-command example in `troubleshooting.md` to the `npx -y @microsoft/workiq@preview` form. Verbose; doable as a sweep.
- **S3** — How to call beta-only endpoints (e.g. `/me/messages/{id}/permanentDelete`) given the entity-tool URL rules forbid `/v1.0/` prefixes. Needs server-side knowledge of how/whether beta routing is automatic.
- **S5** — Confirm whether the `compatibility:` YAML frontmatter is actually consumed by the Copilot CLI skill loader. If not, drop the field and lean on the Prerequisites prose alone.
- **S6** — Sweep ambiguous bare-`workiq` mentions across docs. May be intentional in some places.
- **S10** — Document `accept_eula` and `get_debug_link` MCP tools (listed in `PLUGINS.md` / `AGENTS.md` but undocumented in skill references). Needs binary-side knowledge of intended usage.

Plus a number of LLM-routing polish items from the deep review (e.g. unifying the 8 different URL parameter names — `entityUrls`, `parentUrl`, `entityUrl`, `actionUrl`, `functionUrl`, `blobUrl`, `targetUrl`, `fileUrls` — into a more consistent shape; aligning datetime formats; etc.) that are beyond the scope of a doc-only follow-up.

---

## Validation

- All JSON files parse (`marketplace.json`, `plugin.json`).
- SKILL.md `description` field length: **875 / 1024 chars** (under the runtime cap).
- Marketplace descriptions are now distinct across all 4 plugins listed in `marketplace.json`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
