### PR TITLE
workiq-preview: tighten SKILL.md and references based on evaluation feedback

### DIFF
--- a/plugins/workiq-preview/.mcp.json
+++ b/plugins/workiq-preview/.mcp.json
@@ -1,8 +1,7 @@
 {
   "mcpServers": {
     "workiq-preview": {
-      "command": "npx",
-      "args": ["-y", "@microsoft/workiq@preview", "mcp"]
+      "url": "https://workiq.svc.cloud.microsoft/mcp"
     }
   }
 }

--- a/plugins/workiq-preview/skills/workiq-preview/SKILL.md
+++ b/plugins/workiq-preview/skills/workiq-preview/SKILL.md
@@ -9,7 +9,7 @@ compatibility: >
 
 # WorkIQ
 
-WorkIQ connects AI agents to Microsoft 365 Copilot for workplace intelligence grounded in organizational data. This skill teaches the model how to use the full WorkIQ toolset: the agentic `ask` tool for semantic questions, the fast **entity tools** for direct structured access to M365 data (`fetch`, `create_entity`, `update_entity`, `delete_entity`, `do_action`, `call_function`, `search_paths`, `get_schema`, `fetch_blob`, `upload_blob`), and the **WorkIQ CLI commands** used for one-time setup and configuration (auth login/logout, granting additional permission scopes, viewing or changing config, checking the installed version).
+WorkIQ connects AI agents to Microsoft 365 Copilot for workplace intelligence grounded in organizational data. This skill teaches the model how to use the full WorkIQ toolset: the agentic `ask` tool for semantic questions, the fast **entity tools** for direct structured access to M365 data (`fetch`, `create_entity`, `update_entity`, `delete_entity`, `do_action`, `call_function`, `search_paths`, `get_schema`), and the **WorkIQ CLI commands** used for one-time setup and configuration (auth login/logout, granting additional permission scopes, viewing or changing config, checking the installed version).
 
 ## 🛑 STOP — Read This Before Your First Tool Call
 
@@ -53,6 +53,9 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 | Listing files in a OneDrive/SharePoint folder | "List files in my OneDrive 'Specs' folder" | `fetch` |
 | Listing tasks/plans/buckets in Planner | "List my Planner tasks due this week" | `fetch` |
 | Listing / creating / completing Planner tasks | "Add a task to follow up with finance", "Mark my task done", "List my Planner tasks" | entity tools on `/planner/...` — see `references/tasks-work-iq.md` |
+| List my To Do task lists | "Show me my to-do lists" | `fetch` (`/me/todo/lists`) — subject to server policy |
+| Get a personal contact by name | "Get the contact card for Morgan Avery" | `fetch` (`/me/contacts?$filter=...`) — subject to server policy |
+| List or manage Outlook categories | "What Outlook categories do I have?" | `fetch` (`/me/outlook/masterCategories`); writes subject to server policy |
 | Org chart / direct reports / manager lookup | "Who are Rob's direct reports?" | `fetch` (`/users/{id}/directReports`) |
 | What's new/changed/removed since a point in time | "What's new in my Inbox since this morning?", "What's changed on my calendar since yesterday?", "What's been added to my contacts recently?" | `call_function` (delta — `/me/mailFolders/inbox/messages/delta`, `/me/calendarView/delta?...`, `/me/contacts/delta`). **Never call delta via `fetch`** — see `references/call-function-work-iq.md` |
 | Sending mail, accepting/declining meetings | "Send this draft", "Accept the 2pm meeting" | `do_action` |
@@ -67,6 +70,33 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 > task tracker — that does not satisfy the request and the user cannot see it in Planner.
 > If a WorkIQ task call fails, report the failure; do not silently substitute local storage.
 > See `references/tasks-work-iq.md`.
+
+### Required workflow order — don't stop after a preparatory lookup
+
+Follow the user's request through to completion. A discovery or read call **alone** does not satisfy a request that also asked you to act.
+
+1. **Path discovery** ("endpoint", "available operations", "what can I do with X") → `search_paths` first. Continue to the read/write tool if the prompt also asks to act.
+2. **Schema inspection** ("schema", "data model", "fields", "what does X take") → `get_schema` first. Continue to the write/action tool if the prompt also asks to act.
+3. **Exact entity read or mutation by title/name/channel/thread** → `fetch` to resolve the target's ID, then `update_entity` / `delete_entity` / `do_action`. Do not use `ask` to resolve exact titled events, messages, drafts, folders, Teams chats/channels, or threads.
+4. **Semantic summary/status/decisions** → `ask`. If the prompt then asks to draft, send, create, update, delete, forward, or react, continue with the mutation tool — the `ask` answer alone is incomplete.
+
+### Resolve-then-act — concrete examples
+
+When the user asks to delete, update, send, forward, copy, move, or react to something, you **must** call the write tool after resolving the entity. A final answer without the mutation is incomplete.
+
+| User request | Step 1: resolve | Step 2: act (required) |
+|---|---|---|
+| "Mark email as read" | `fetch` to find the message | `update_entity` `/me/messages/{id}` with `{"isRead": true}` |
+| "Forward email to X" | `fetch` to find the message | `do_action` `/me/messages/{id}/forward` |
+| "Send email to X" | — | `do_action` `/me/sendMail` |
+| "Copy file to folder" | `fetch` to find file and target folder | `do_action` `/me/drive/items/{id}/copy` |
+| "Set presence to busy" | — | `do_action` `/me/presence/setUserPreferredPresence` — see `references/teams-work-iq.md` |
+| "React to Teams message" | `fetch` to find the message | `do_action` `/teams/{teamId}/channels/{channelId}/messages/{messageId}/setReaction` |
+| "Delete" any entity | `fetch` to find it | `delete_entity` on the entity URL |
+| "Update/rename/change" any entity | `fetch` to find it | `update_entity` on the entity URL |
+| "Create draft and send" | `create_entity` to draft | `do_action` `/me/messages/{id}/send` |
+
+Common failure: fetching the entity and stopping, asking the user "did you want me to do anything else?", or saying "I found it." The user asked you to do something — finish it.
 
 **When in doubt, use WorkIQ.** It's better to query and get no results than to miss workplace context.
 
@@ -83,6 +113,18 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 >   tool response confirms it (2xx/created/updated). If you could not find the target or the
 >   write failed, say so — do not substitute a different action (e.g., sending a new email
 >   instead of replying) and report the original request as completed.
+
+### Grounding rules
+
+- **Discovery and schema answers come from tool results.** State only paths, operations, fields, required/writable properties, and parameters present in the `search_paths` or `get_schema` response. On partial evidence, say what was confirmed and what wasn't — do not fill gaps from general Graph knowledge.
+- **Be precise about tool outcomes.** Do not claim success, failure, existence, or a specific error unless the exact outcome is in the tool result. On null/empty/ambiguous results, say so.
+- **Call at least one WorkIQ tool before answering any M365 question.** Exceptions: non-workplace questions, or questions about this skill's docs.
+- **Honor paging.** If a response includes `@odata.nextLink`, do not present the first page as complete. Continue fetching when the user asks for all/every/complete, or say the answer is partial.
+
+### Don't substitute web search or CLI introspection
+
+- ❌ `web_fetch` / web search **as the first move** for Graph or M365. WorkIQ is the source of truth — call `get_schema` (for fields) or `search_paths` (for endpoints) first. `web_fetch` is a fallback **only after** WorkIQ returns no useful result.
+- ❌ `fetch_copilot_cli_documentation` for workplace questions — it describes the CLI itself, not M365. When the user says "these tools", "what's available", "what can I do" about mail/calendar/tasks/files/contacts/Teams/channels/chats/OneDrive/SharePoint, call `search_paths`.
 
 ## Prerequisites
 
@@ -168,13 +210,36 @@ Entity tools provide **fast, direct access to specific M365 data** via Work IQ A
 
 | Resource | Path root | Common ops |
 |----------|-----------|-----------|
-| Mail | `/me/messages`, `/me/mailFolders` | list/get/create draft/update/delete; send via `/me/sendMail`, reply/forward/move via `/me/messages/{id}/{action}` |
+| Mail | `/me/messages`, `/me/mailFolders` | list/get/create draft/update/delete; send via `/me/sendMail`, reply/forward/move via `/me/messages/{id}/{action}`; subject search via `$search` (not `$filter=contains`) — see `references/mail-work-iq.md` |
 | Calendar | `/me/events`, `/me/calendarView` | list/get/create/update/delete; accept/decline via `/me/events/{id}/{action}` |
 | Planner | `/me/planner/plans`, `/planner/tasks` | list/create/update/complete/delete — see `references/tasks-work-iq.md` |
 | Teams | `/me/chats`, `/chats/{chatId}/messages`, `/me/joinedTeams`, `/teams/{teamId}/channels/{channelId}/messages`, `/me/presence` | chats vs channels are different surfaces — see `references/teams-work-iq.md` |
 | People | `/me`, `/users/{id}`, `/users/{id}/directReports`, `/me/manager`, `/me/contacts` | profile, org, contacts — see directory-vs-contacts warning below |
-| Files | `/me/drive`, `/drives/{id}`, `/sites/{id}` | list/get; download via `fetch_blob`, upload via `upload_blob` |
+| To Do | `/me/todo/lists`, `/me/todo/lists/{listId}/tasks` | list/create/update/delete — **commonly policy-denied**, see note below |
+| Outlook categories | `/me/outlook/masterCategories` | list/get/create/update/delete — writes commonly policy-denied |
+| Files | `/me/drive`, `/drives/{id}`, `/sites/{id}` | list/get JSON metadata only — binary content (file bytes, attachment payloads) is not released yet, see the deny rule below |
 | Change tracking | `/me/mailFolders/inbox/messages/delta`, `/me/calendarView/delta?...`, `/me/contacts/delta` | "what's new/changed since" — via `call_function` only, never `fetch` |
+
+> **Server may deny families by policy.** Tenants can disable specific path families
+> server-side. If a call returns `Access denied for path: <X>`, the path isn't in the
+> tenant's allowlist — **do not retry, do not fall back to a different path, do not call `ask`
+> as a workaround.** Tell the user the path is policy-denied. As of the current preview,
+> `/me/todo/*`, `/me/contacts`, and writes on `/me/outlook/masterCategories` are commonly
+> affected — `search_paths` confirms what's exposed for the connected tenant.
+
+### 🛑 Binary file content is not yet released — `fetch_blob` and `upload_blob` are not callable today
+
+`fetch_blob` and `upload_blob` are documented for future reference, but **they are not part of the current preview MCP surface**. Attempting to call them returns `tool does not exist`. Do not call them, do not search for them in your tool list, do not invent them from a similar name (e.g. `download_file`, `get_blob`, `put_file`).
+
+**You cannot retrieve or send raw bytes through this preview build yet** — no file payload, no attachment payload, no profile photo bytes, no base64 blob, no inline binary content.
+
+When the user asks to download a file, upload a local file, get attachment content, or fetch a profile photo:
+
+1. **Confirm the request and tell the user this preview build does not support binary file content yet.**
+2. **Return the file's web URL** instead — `fetch` `/me/drive/items/{id}` (or the SharePoint equivalent) returns a `webUrl` the user can open in OneDrive / SharePoint / Outlook directly. For an attachment, return the parent message URL so the user can open it in Outlook.
+3. **Never fabricate binary content.** Do not invent a base64 string, an `@odata.mediaContentType`, or an `@microsoft.graph.downloadUrl` to satisfy the request. If the user needs the bytes, point them at the web URL — they will download from there.
+
+If the user explicitly asks "why can't you download it directly?" — say the binary-download and upload tools (`fetch_blob`, `upload_blob`) are not yet released in this WorkIQ preview build; the structured-metadata tools (`fetch`, `create_entity`, etc.) are the full available surface today.
 
 ### ⚠️ Directory users and personal contacts are different stores
 
@@ -190,13 +255,36 @@ contacts) are **separate entity types with incompatible IDs**:
 - If the person exists only in the directory and not in `/me/contacts`, say so — to update their
   details as a contact you must create a personal contact first.
 
-### 🛑 Schema/discovery questions stay on MCP — never `web_fetch`
+### 🛑 Schema/discovery questions stay on MCP — never `web_fetch` or CLI introspection
 
 When the user asks about a Graph **schema, payload, parameters, fields, or which endpoints exist**
 ("what does sendMail take?", "which fields are updatable?", "what endpoints handle email?"),
 answer with `get_schema` / `search_paths`. **Do not** answer from the builtin
-`web_fetch` against public docs — those calls produce no MCP evidence and are treated as not
-answering the question. Resolve the WorkIQ tool name (see above) and call the MCP tool.
+`web_fetch` against public docs or from `fetch_copilot_cli_documentation` — those calls produce no
+MCP evidence and are treated as not answering the question. Resolve the WorkIQ tool name (see
+above) and call the MCP tool.
+
+### Efficiency rules — minimize tool calls
+
+**Do not loop through `search_paths` / `get_schema` / `fetch` repeatedly.** Common anti-patterns:
+
+- ❌ Calling `search_paths` 3+ times for the same surface area.
+- ❌ Calling `get_schema` on paths you already know (contacts, messages, events, drive items).
+- ❌ Using `fetch` to "explore" when the path is already implied by context.
+- ❌ Falling back to dozens of `fetch` calls when `ask` fails — report the failure instead.
+
+**Do:** use the path patterns in this document to route directly to the correct tool in 1–2
+calls. If you need the entity ID first, one `fetch` to resolve, then one write tool call.
+
+### Missing information — use `fetch` to disambiguate, don't give up
+
+When the user's request is missing a required piece of information (e.g., "delete my draft" with
+no subject named, an empty title, or a generic "the meeting"):
+
+1. Use `fetch` to list the available options (e.g., `fetch` `/me/events`, `/me/messages`, `/me/mailFolders`).
+2. Ask the user to pick from the results.
+3. Do **not** silently abandon the request with zero tool calls.
+4. Do **not** proceed with a write operation using empty or invented data.
 
 ### 🔁 Resolve-then-act — do not loop searches
 
@@ -215,7 +303,7 @@ To act on a named entity ("the X email", "my Y task", "the Z draft"):
 
 ### ⚠️ URL Format Rules (ALL entity tools)
 
-All URL parameters (`entityUrls`, `parentUrl`, `entityUrl`, `actionUrl`, `functionUrl`, `blobUrl`, `targetUrl`) **must**:
+All URL parameters (`entityUrls`, `parentUrl`, `entityUrl`, `actionUrl`, `functionUrl`) **must**:
 
 1. **Server-relative path only** — start with `/` and **omit** any scheme, authority, or API-version prefix. Valid path roots include `/me/...`, `/users/...`, `/teams/...`, `/groups/...`, `/sites/...`, `/drives/...`, `/planner/...`, and others — anything Graph exposes.
    - ❌ `https://graph.microsoft.com/v1.0/me/messages`
@@ -227,15 +315,15 @@ All URL parameters (`entityUrls`, `parentUrl`, `entityUrl`, `actionUrl`, `functi
    - ✅ `$orderby=receivedDateTime%20desc`
    - **Exception:** OData property paths (the `/` separator between navigation properties, e.g. `start/dateTime`, `from/emailAddress/address`) are **not** encoded. The `/` only gets encoded when it appears inside a string literal value.
 
-### ⚠️ `jsonBody` Format Rules (write tools)
+### `jsonBody` Format Rules (write tools)
 
-`create_entity`, `update_entity`, `do_action`, and `call_function` accept a `jsonBody` parameter. **`jsonBody` is a string** containing JSON, **not** a JSON object — the value must be a JSON-encoded string with quotes escaped.
+`create_entity`, `update_entity`, `do_action`, and `call_function` accept a `jsonBody` parameter. **Both shapes are accepted** — a JSON object or a JSON-encoded string. Pick whichever your runtime makes easier; both produce the same result.
 
-- ❌ `"jsonBody": { "subject": "Hello" }` — object, rejected by schema
-- ❌ `"jsonBody": "{"subject":"Hello"}"` — broken quoting
+- ✅ `"jsonBody": { "subject": "Hello" }` — JSON object
 - ✅ `"jsonBody": "{\"subject\":\"Hello\"}"` — JSON-encoded string
+- ❌ `"jsonBody": "{"subject":"Hello"}"` — broken quoting (neither valid JSON nor a valid escaped string)
 
-If a write tool returns a schema error mentioning `jsonBody` type, this is almost certainly the cause. Re-serialize the body and retry.
+If a write tool returns a schema error mentioning `jsonBody` shape, check the JSON itself (mismatched braces, unescaped quotes inside the string form, wrong wrapper). Object form is the simplest to get right.
 
 ### ⚠️ Placeholders in examples are not literals
 
@@ -245,18 +333,39 @@ Reference examples use `{id}`, `{listId}`, `{teamId}`, `{taskId}`, `{driveId}`, 
 
 `do_action` (especially `/me/sendMail`, `/forward`, `/accept`, `/decline`, `/permanentDelete`) and write-side `create_entity` / `update_entity` / `delete_entity` calls take effect immediately and are visible to other people (recipients, meeting organizers) or unrecoverable. **Before invoking any write tool, summarize what you're about to do and get the user's confirmation.** This is especially important for sendMail, forward, decline, and permanentDelete.
 
+### "Draft", "compose", "prepare reply" requires a persisted draft
+
+When the user says "draft an email", "compose a reply", "prepare a response", or any variant
+asking the draft to *exist* (not just suggest wording), call `create_entity` to POST:
+
+- `/me/messages` for a fresh draft
+- `/me/messages/{id}/createReply`, `/createReplyAll`, or `/createForward` for replies/forwards
+  (these are `create_entity` POSTs, **not** `do_action`)
+
+Generating draft text inline does NOT satisfy the request — the user can't open it in Outlook.
+A common failure: call `ask` for the summary half of a "summarize then draft" chain and stop;
+the `create_entity` step is required.
+
+### Schema for action verbs
+
+Action verbs (camelCase verb at end of path: `/me/sendMail`, `/me/messages/{id}/forward`,
+`/me/events/{id}/accept`, `/decline`, `/copy`, `/move`, `/reply`, `/getSchedule`,
+`/findMeetingTimes`) — get the body schema via `get_schema` with `operationType: "action"`. Do
+**not** substitute a related entity's schema — the wrapper shape differs (`sendMail` →
+`{Message, SaveToSentItems}`, `copy` → `{destinationId}`, etc.).
+
+### Entity tool reference
+
 | Tool | Purpose | Key Parameters |
 |------|---------|----------------|
-| `search_paths` | Discover available API paths | `filter` (regex), `backend` |
-| `get_schema` | Inspect fields and body shape for a path | `path`, `httpMethod`, `apiVersion` |
+| `search_paths` | Discover available API paths | `filter` (regex, **required**) |
+| `get_schema` | Inspect fields and body shape for a path | `path`, `operationType` (`fetch`/`create`/`update`/`action`), `format` |
 | `fetch` | Fetch entities by path (GET) | `entityUrls[]` — supports OData (`$filter`, `$select`, `$top`) |
 | `call_function` | Call named OData functions — GET-shaped, side-effect-free, parenthesised inline params (e.g. `delta`, `reminderView`) | `functionUrl` with inline function params |
 | `create_entity` | Create a new entity (POST to collection) | `parentUrl`, `jsonBody` |
 | `update_entity` | Update fields on an existing entity (PATCH) | `entityUrl` with ID, `jsonBody` |
 | `delete_entity` | Delete an entity (DELETE) | `entityUrl` with ID |
 | `do_action` | Execute an action — send, copy, move, accept (POST) | `actionUrl`, `jsonBody` (optional) |
-| `fetch_blob` | Download binary content (files, attachments) | `blobUrl` |
-| `upload_blob` | Upload a local file (PUT) | `targetUrl`, `filePath` |
 
 Read the relevant reference file for full parameter details and examples:
 
@@ -265,12 +374,11 @@ Read the relevant reference file for full parameter details and examples:
 - `references/fetch-work-iq.md` — if you need to fetch structured or filtered M365 data
 - `references/call-function-work-iq.md` — if the path uses OData function call syntax (e.g., `reminderView(...)`, `delta`)
 - `references/create-entity-work-iq.md` — if you need to create a new calendar event, email draft, task, etc.
+- `references/mail-work-iq.md` — if you need to find, draft, send, reply, forward, move, or delete mail (covers `$search` vs `$filter` and the mail-delta endpoint)
 - `references/tasks-work-iq.md` — if you need to list, create, update, complete, or delete Planner tasks
 - `references/teams-work-iq.md` — if you need to send, reply, react, or read Teams chat/channel messages, or get/set presence
 - `references/update-entity-work-iq.md` — if you need to update fields on an existing entity
 - `references/delete-entity-work-iq.md` — if you need to delete an entity
 - `references/do-action-work-iq.md` — if you need to send mail, accept/decline meetings, copy/move messages
-- `references/fetch-blob-work-iq.md` — if you need to download a file or attachment
-- `references/upload-blob-work-iq.md` — if you need to upload a file to OneDrive or SharePoint
 - `references/troubleshooting.md` — if a tool call fails unexpectedly, returns an error, or behaves differently than documented
 - `references/cli-commands.md` — if you need to run WorkIQ CLI commands directly (auth, consent, config, version) outside the MCP server

--- a/plugins/workiq-preview/skills/workiq-preview/references/ask-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/ask-work-iq.md
@@ -25,6 +25,13 @@ Use `ask` when:
 
 Prefer `ask` over entity tools when the question is open-ended or exploratory. Switch to entity tools when you need precise, structured data or need to write/modify data.
 
+## Do NOT use `ask` as a shortcut for:
+
+- **API / path questions** ("endpoint", "available operations", "what can I do with…") → `search_paths`
+- **Schema / field / body-shape questions** ("what does sendMail take?", "what fields are required?") → `get_schema`
+- **Exact mutations by title / name / thread / channel** ("delete the X event", "react to the Y message") → resolve with `fetch`, then call the write/action tool directly
+- **A "summarize then draft/send/create/update/delete/forward/react" chain** — continue with the mutation tool after `ask`. The `ask` answer alone does not satisfy the second half of the request.
+
 ## Examples
 
 ### People and expertise

--- a/plugins/workiq-preview/skills/workiq-preview/references/call-function-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/call-function-work-iq.md
@@ -17,7 +17,7 @@ Call an OData function via HTTP GET. Functions are **side-effect-free** named op
 - **Any "what's new / what's changed / what was added or removed since X" question** — that is a
   delta query, and this tool is the only correct route for it
 
-If you're not sure whether something is a function or an action, run `get_schema` on the path with `httpMethod: "get"` first. If no GET schema is returned but POST is, route to `do_action`.
+If you're not sure whether something is a function or an action, run `get_schema` on the path with `operationType: "fetch"` first. If no `fetch` schema is returned but `action` is, route to `do_action`.
 
 ## Delta queries (change tracking)
 

--- a/plugins/workiq-preview/skills/workiq-preview/references/create-entity-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/create-entity-work-iq.md
@@ -1,29 +1,29 @@
 # create_entity
 
-Create a new WorkIQ entity by POSTing to a collection path. Use this to create calendar events, draft emails, tasks, Teams messages, and other M365 resources.
+POST a new WorkIQ entity to a collection — calendar events, draft emails, tasks, Teams messages, other M365 resources.
 
-> **⚠️ Writes are persistent.** Creating a calendar event sends invitations to attendees; creating a draft email is invisible until sent but takes up space; creating a task or message in a shared list is visible to collaborators. **Before invoking, summarize what you're about to create (subject, attendees, due date, parent list/folder) and get the user's explicit confirmation.**
+> **⚠️ Writes are persistent.** Creating an event sends invitations; creating a task or shared-list message is visible to collaborators. **Summarize what you're creating (subject, attendees, due date, parent) and get explicit user confirmation before invoking.**
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `parentUrl` | string | Yes | The parent collection path to POST to (e.g., `/me/events`, `/me/messages`). Do not include an ID — this creates a new item. Must be relative to the domain root — start with `/`, do not include a scheme or authority (`https://graph.microsoft.com` ❌, `/me/events` ✅). URL-encode any special characters in path segments. |
-| `jsonBody` | string | Yes | JSON-encoded string with the fields for the new entity. Use `get_schema` on the path with `httpMethod: "post"` first if unsure of required fields. |
+| `parentUrl` | string | Yes | Parent collection path (`/me/events`, `/me/messages`). No ID — this creates a new item. Server-relative, starts with `/`, no scheme. URL-encode special characters. |
+| `jsonBody` | object \| string | Yes | Fields for the new entity, supplied as a JSON object (`{"subject":"Hi"}`) or a JSON-encoded string. Run `get_schema` with `operationType: "create"` first if unsure. |
 
 ## When to Use
 
-- Creating a new calendar event
-- Creating a draft email (use `do_action` with `/me/sendMail` to send immediately)
-- Creating a new Planner task
-- Creating a new Teams channel message
-- Any time you need to POST a new item to a collection
+- New calendar event
+- Draft email (use `do_action` `/me/sendMail` to send immediately)
+- New Planner task
+- New Teams channel message
+- Any POST creating a new item in a collection
 
 ## Workflow
 
-1. Call `get_schema` with the collection URL and `httpMethod: "post"` to confirm required fields
-2. Call `create_entity` with the collection URL and a valid body
-3. Save the returned `id` if you need to reference or update the entity later
+1. `get_schema` with the collection URL and `operationType: "create"` to confirm required fields
+2. `create_entity` with the collection URL and a valid body
+3. Save the returned `id` for later updates
 
 ## Examples
 

--- a/plugins/workiq-preview/skills/workiq-preview/references/delete-entity-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/delete-entity-work-iq.md
@@ -1,34 +1,31 @@
 # delete_entity
 
-Delete a WorkIQ entity via HTTP DELETE. This is a permanent operation — use with care, especially for emails and calendar events.
+DELETE a WorkIQ entity. Permanent — use with care, especially for emails and calendar events.
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityUrl` | string | Yes | The entity path including the item's ID (e.g., `/me/events/{id}`). Must be relative to the domain root — start with `/`, do not include a scheme or authority (`https://graph.microsoft.com` ❌, `/me/events/{id}` ✅). URL-encode any special characters in path segments. |
+| `entityUrl` | string | Yes | Entity path including ID (`/me/events/{id}`). Server-relative, starts with `/`, no scheme. URL-encode special characters. |
+| `headers` | object | No | Optional HTTP request headers. If the operation's schema declares an `If-Match` header parameter, you MUST set it to the `@odata.etag` value from the latest read of the same entity. |
 
 ## When to Use
 
-- Deleting a calendar event
-- Deleting a draft email
-- Removing a Planner task
-- Deleting a Teams message (where permitted)
+- Delete a calendar event
+- Delete a draft email
+- Remove a Planner task
+- Delete a Teams message (where permitted)
 
 ## Gotchas
 
-- **Email deletion moves to Deleted Items**, it does not permanently delete. That is the right
-  default for any "delete / remove / get rid of this email" request — use this tool. Reach for
-  `do_action` with `/me/messages/{id}/permanentDelete` only when the user explicitly
-  asks for permanent, unrecoverable removal, and only against the **single resolved message ID**
-  — never loop permanentDelete across a list of messages.
-- **Calendar event deletion** removes it from the calendar and sends cancellation notices to attendees if it was an organized meeting.
-- Always confirm the entity ID with `fetch` before deleting to avoid removing the wrong item.
+- **Email delete moves to Deleted Items** — that's the right default for any "delete / remove / get rid of this email" request. Reach for `do_action` with `/me/messages/{id}/permanentDelete` only when the user explicitly asks for permanent, unrecoverable removal, and only against the **single resolved message ID** — never loop `permanentDelete` across a list of messages.
+- **Event delete** sends cancellation notices if it was an organized meeting.
+- Confirm the entity ID with `fetch` before deleting.
 
 ## Workflow
 
-1. Use `fetch` to confirm you have the correct entity and its ID
-2. Call `delete_entity` with the entity's full path including ID
+1. `fetch` to confirm the correct entity and ID
+2. `delete_entity` with the entity's full path including ID
 
 ## Examples
 

--- a/plugins/workiq-preview/skills/workiq-preview/references/do-action-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/do-action-work-iq.md
@@ -1,30 +1,31 @@
 # do_action
 
-Execute a WorkIQ action via HTTP POST. Actions are named operations that perform a task (rather than creating a resource) — such as sending an email, copying a file, moving a message, accepting a meeting invitation, or computing free/busy availability across multiple calendars.
+POST a WorkIQ action — a named operation that performs a task (send mail, copy/move messages, accept/decline a meeting, compute free/busy) rather than creating a resource.
 
-> **⚠️ Write actions execute immediately.** `/me/sendMail`, `/forward`, `/accept`, `/decline`, `/permanentDelete`, and similar verbs take effect right away and are visible to other people or unrecoverable. **Before invoking, summarize the action (recipients, subject, body, target ID) and get the user's explicit confirmation.** Do not auto-send drafts or auto-respond to meeting invites without confirmation.
+> **📘 Action body shapes live here.** This file is the source of truth for action `jsonBody` shapes. You can also call `get_schema` with `operationType: "action"` to retrieve the schema directly.
+
+> **⚠️ Writes execute immediately.** `/me/sendMail`, `/forward`, `/accept`, `/decline`, `/permanentDelete`, and similar verbs are immediate and visible to others (or unrecoverable). **Summarize the action (recipients, subject, body, target) and get explicit user confirmation before invoking.** Never auto-send drafts or auto-respond to meeting invites.
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `actionUrl` | string | Yes | The action path (e.g., `/me/sendMail`, `/me/messages/{id}/copy`). Must be relative to the domain root — start with `/`, do not include a scheme or authority (`https://graph.microsoft.com` ❌, `/me/sendMail` ✅). URL-encode any special characters in path segments or query values. |
-| `jsonBody` | string | No | JSON-encoded string with action parameters. Some actions require a body; others take no parameters. |
+| `actionUrl` | string | Yes | Action path, server-relative (`/me/sendMail`, `/me/messages/{id}/copy`). Start with `/`, no scheme or authority. URL-encode special characters. |
+| `jsonBody` | object \| string | No | Action parameters as a JSON object (`{"comment":"FYI"}`) or a JSON-encoded string. Some actions take no body. |
 
 ## When to Use
 
-- Sending an email (rather than just creating a draft)
-- Accepting, declining, or tentatively accepting a meeting invitation
-- Copying or moving a message to another folder
-- Forwarding a message
-- Replying to a message
-- Computing free/busy availability for multiple users (`getSchedule`)
-- Reacting to a Teams message (`setReaction`)
-- Setting the user's Teams presence (`setUserPreferredPresence`)
-- Initiating a large file upload session (`createUploadSession`)
-- Subscribing to change notifications
+- Send mail (vs. creating a draft) — `/me/sendMail`, `/me/messages/{id}/send`
+- Accept / decline / tentatively accept a meeting — `/me/events/{id}/{accept|decline|tentativelyAccept}`
+- Copy or move a message — `/me/messages/{id}/{copy|move}`
+- Forward or reply — `/me/messages/{id}/{forward|reply}`
+- Compute free/busy across multiple users — `/me/calendar/getSchedule`
+- React to a Teams message — `/chats/{chatId}/messages/{messageId}/setReaction`
+- Set the user's Teams presence — `/me/presence/setUserPreferredPresence`
+- Initiate a large file upload session — `/me/drive/.../createUploadSession`
+- Subscribe to change notifications
 
-Distinguish from `create_entity`: use `do_action` for verbs (send, copy, move, accept, reply, getSchedule) rather than creating a new stored resource. If an operation has a function-like name (`getSchedule`, `findMeetingTimes`) but takes a JSON body, it's still an action — POST it through this tool.
+Vs. `create_entity`: use `do_action` for verbs (send, copy, move, accept, reply, getSchedule); use `create_entity` to create a new stored resource. Function-shaped names that still take a JSON body (`getSchedule`, `findMeetingTimes`) are actions — POST them here.
 
 ## Examples
 
@@ -127,4 +128,18 @@ For channel messages use the `/teams/{teamId}/channels/{channelId}/messages/{mes
 }
 ```
 
-The response returns an `uploadUrl` you can PUT chunks to. Use this for files larger than 4MB (`upload_blob`'s simple PUT limit).
+The response returns an `uploadUrl` you can PUT chunks to. **However, this skill does not expose a binary-upload tool** — see the deny rule in `SKILL.md`. Surface the `uploadUrl` to the user so they can complete the upload themselves; do not attempt to PUT bytes from inside the model.
+
+## Common failures (do not retry)
+
+`do_action` failures from Microsoft Graph are almost always permanent on the same payload. **Do not retry the same call** after any of these — repeated identical POSTs return the exact same error and burn tool budget without producing new information.
+
+| HTTP / code | Meaning | Action |
+|---|---|---|
+| `403` + `"Missing scope permissions"` | The signed-in user has not consented to the Graph scope this action needs (e.g. `Presence.ReadWrite` for `/me/presence/setPresence`, `Mail.Send` for `/me/sendMail`, `Calendars.ReadWrite` for `/me/events/{id}/accept`). | Stop. Tell the user the consent is missing and suggest `workiq auth consent --scopes <Scope>`. See [`troubleshooting.md`](troubleshooting.md#http-403-forbidden-on-an-entity-tool-call). |
+| `403` + empty / generic `Forbidden` | Tenant policy or admin-controlled action (e.g. presence write in a managed tenant, send-as another mailbox). The body has no scope hint because the directory denied the call before scope evaluation. | Stop. Tell the user the operation is policy-denied. Do NOT iterate through sibling action verbs (`setUserPreferredPresence` ↔ `setPresence`) — they share the same policy gate. |
+| `400` / `BadRequest` on the body | The `jsonBody` wrapper shape is wrong (e.g. `sendMail` expects `{Message, SaveToSentItems}`, not a raw `Message`). | Stop. Re-read this file's JSON sample for that action; do not re-send the same body. |
+| `404` on `actionUrl` | The entity ID embedded in the path is stale, or the action verb does not exist on this resource family. | Stop. Re-`fetch` to get the current ID, OR re-check `search_paths` for the right action verb. |
+
+**Especially for `/me/presence/*`:** if the first `setPresence` or `setUserPreferredPresence` POST returns 403, the second will too. Both verbs share the `Presence.ReadWrite[.All]` scope gate. Stop after one 403, surface the failure, and (for missing-consent flavor) suggest `workiq auth consent --scopes Presence.ReadWrite`.
+

--- a/plugins/workiq-preview/skills/workiq-preview/references/fetch-blob-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/fetch-blob-work-iq.md
@@ -1,5 +1,7 @@
 # fetch_blob
 
+> ⚠️ **Not released yet.** `fetch_blob` is documented here for future reference but is **not part of the current preview MCP surface**. Calling it from this preview build returns `tool does not exist`. When a user asks to download a file or fetch attachment bytes today, return the entity's `webUrl` (or the parent message URL for an attachment) and tell the user this preview build can't stream raw bytes yet — see the [Binary file content](../SKILL.md) section in `SKILL.md` for the canonical workflow.
+
 Download binary content from a WorkIQ path. Use this for file content, email attachments, document downloads, and any other binary resource from Microsoft 365.
 
 ## Parameters

--- a/plugins/workiq-preview/skills/workiq-preview/references/fetch-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/fetch-work-iq.md
@@ -17,17 +17,23 @@ Fetch one or more WorkIQ entities by path using HTTP GET. Use this for precise, 
 
 Prefer `ask` for open-ended questions. Use `fetch` when you need precise, filtered, or structured data.
 
+Use `fetch` (not `ask`) to resolve exact targets before mutations — find an event ID before deleting/updating, a draft before adding recipients or sending, a Teams chat/channel/message before editing/reacting/posting, a mail thread before reply/forward/move/mark-read.
+
+For exact reads ("show/list/get latest messages", "list members", "show my chats", "retrieve the event titled…"), prefer filtered `fetch` or a known function path. Do not answer from general knowledge, local SQL, or `ask` unless the prompt asks for synthesis.
+
 > **⚠️ Not for delta queries.** Calling `/.../delta` or `/.../delta()` through `fetch`
 > fails — delta is an OData **function** and must go through `call_function`. See
 > `references/call-function-work-iq.md`.
 
 ## Multi-fetch caveats
 
-- A single call accepts **at most 50** entity URLs.
 - The batch result can report an error when **any one** URL fails, even if the other URLs
   returned data. If a multi-fetch errors, don't discard it — check for successful payloads
   inside the response, and re-issue only the failing URL on its own to isolate the problem.
   When a URL might fail (permissions, existence unknown), prefer small batches or single URLs.
+- Large URL lists also stack per-URL latency into a single tool-call window and raise the
+  odds of one failure poisoning the batch. Prefer focused batches over speculative bulk
+  fetches.
 
 ## Pagination
 
@@ -71,13 +77,29 @@ Common URL encodings for OData query values:
 
 ## OData Query Tips
 
+**Always include `$select`** with only the fields you need to reduce response size (e.g., `/me/messages?$select=id,subject,from`). For collection endpoints, include `$top` to bound results.
+
 | Parameter | Purpose | Example |
 |-----------|---------|---------|
-| `$top` | Limit result count | `$top=10` |
+| `$top` | Limit result count (some APIs reject `$top` — e.g., `/me/chats/{id}/members`; omit it there) | `$top=10` |
 | `$filter` | Filter results | `$filter=isRead%20eq%20false` |
 | `$select` | Return only specified fields | `$select=subject,from,receivedDateTime` |
 | `$orderby` | Sort results | `$orderby=receivedDateTime%20desc` |
 | `$expand` | Include related entities inline | `$expand=attachments` |
+
+## Binary file content is not available
+
+This skill **cannot** download file bytes, attachment payloads, profile photo bytes, or any other binary content. There is no `fetch_blob` tool exposed.
+
+Do **not** call `fetch` against paths ending in `/content` or `$value` (e.g. `/me/drive/items/{id}/content`, `/me/messages/{id}/attachments/{id}/$value`) — `fetch` only returns JSON metadata envelopes, and it will not give you the raw bytes either.
+
+When the user asks for a file's content:
+
+1. Tell the user this skill cannot return the binary content directly.
+2. `fetch` the item's metadata (e.g. `/me/drive/items/{id}`) and return the `webUrl` so the user can open and download it in OneDrive / SharePoint / Outlook directly.
+3. For an attachment, return the parent message's `webLink` so the user can open it in Outlook.
+
+Never fabricate base64 content, `@odata.mediaContentType`, or an `@microsoft.graph.downloadUrl` value to satisfy the request.
 
 ## Examples
 

--- a/plugins/workiq-preview/skills/workiq-preview/references/get-schema-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/get-schema-work-iq.md
@@ -1,48 +1,80 @@
 # get_schema
 
-Retrieve the OpenAPI schema for a WorkIQ API path or operation. Use this to understand what fields are available on an entity, what parameters a query accepts, and what body shape is required for create/update operations.
+Retrieve the OpenAPI schema for a WorkIQ path or operation — fields available on an entity, query parameters, body shape for create/update/action.
+
+> **Routing rule:** call `get_schema` once with `path` set to the path of interest AND the right `operationType`:
+>
+> - **Collection reads** (`/me/messages`, `/me/events`) → `operationType: "fetch"`
+> - **Creates** (POST to a collection, e.g. `/me/events`, `/me/messages`) → `operationType: "create"`
+> - **Updates** (PATCH on a specific item, e.g. `/me/messages/{id}`) → `operationType: "update"`
+> - **Action verbs** (camelCase/PascalCase verb at end of path: `/me/sendMail`, `/me/messages/{id}/forward`, `/me/events/{id}/{accept|decline|tentativelyAccept}`, `/copy`, `/move`, `/reply`, `/getSchedule`, `/findMeetingTimes`) → `operationType: "action"`
+>
+> Each path supports only the values matching its real operations — wrong values return precise errors like `No 'create' operation for path: me/sendMail`. When that happens, **do not** retry blindly; the mapping above is correct. Do not fall back to a related entity path (e.g. `/me/messages`) for an action-verb schema — the wrapper shape differs.
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `path` | string | No* | Entity path (e.g., `/me/messages`). Preferred over `operationIds`. |
-| `operationIds` | string | No* | Operation ID (e.g., `me.CreateMessages`). Use if you don't know the path. |
-| `httpMethod` | string | No | HTTP method filter: `get`, `post`, `patch`, or `delete`. Narrows results when a path supports multiple methods. |
-| `apiVersion` | string | No | `v1.0` (default) or `beta`. Use `beta` for preview features. |
+| `path` | string | **Yes** | Entity path (`/me/messages`). Server-relative, starts with `/`. |
+| `operationType` | string | **Yes** | One of `fetch` (GET), `create` (POST to collection), `update` (PATCH), `action` (action verb body). Each path supports only the matching subset; wrong values error like `No 'create' operation for path: me/sendMail`. |
+| `format` | string | No | `jsonschema`, `typescript`, or `cddl`. Defaults to `cddl`. |
 
-*Provide either `path` or `operationIds` — at least one is required.
+> **⚠️ Parameter shape gotchas.**
+> - `operationType` is the **only** way to pick the operation flavor — no `httpMethod`, `method`, `verb`, `apiVersion`, `operationIds`, or `backend` param exists on `get_schema`. `fetch`→GET, `create`→POST to a collection, `update`→PATCH, `action`→action verb body.
 
 ## When to Use
 
-- Before calling `create_entity` or `update_entity` to understand the required body shape
-- When `fetch` returns unfamiliar fields and you want to understand their meaning
-- When you need to know what OData query parameters (`$filter`, `$select`, `$orderby`) are supported
-- To check if a `beta` endpoint has fields not available in `v1.0`
+- Before `create_entity` / `update_entity` to confirm body shape
+- When `fetch` returns unfamiliar fields
+- To check supported OData query params (`$filter`, `$select`, `$orderby`)
+- To check `beta` fields not in `v1.0`
 
 ## Examples
 
-### Get the schema for reading messages
+### Read schema for messages
 ```json
-{ "path": "/me/messages", "httpMethod": "get" }
+{ "path": "/me/messages", "operationType": "fetch" }
 ```
 
-### Get the schema for creating a calendar event
+### Create schema for a calendar event
 ```json
-{ "path": "/me/events", "httpMethod": "post" }
+{ "path": "/me/events", "operationType": "create" }
 ```
 
-### Get the schema for updating a message
+### Update schema for a message
 ```json
-{ "path": "/me/messages/{id}", "httpMethod": "patch" }
+{ "path": "/me/messages/{id}", "operationType": "update" }
 ```
 
-### Get a beta schema
+### TypeScript format
 ```json
-{ "path": "/me/messages", "httpMethod": "get", "apiVersion": "beta" }
+{ "path": "/me/messages", "operationType": "fetch", "format": "typescript" }
 ```
 
-### Look up by operation ID
+### Action verb schema (sendMail)
 ```json
-{ "operationIds": "me.CreateMessages" }
+{ "path": "/me/sendMail", "operationType": "action" }
 ```
+
+## Asking for the "schema" of an action
+
+For "schema for sending an email" / "what parameters does sendMail take?" / "body for accepting a meeting?", call `get_schema` **once** with `{ "path": "<action-path>", "operationType": "action" }`. This returns the request-body JSON Schema — for `/me/sendMail`, `Message` (a `microsoft.graph.message`) plus `SaveToSentItems` (boolean). Surface those properties directly.
+
+Do **not**:
+
+- Pass `create`/`fetch`/`update` on an action verb — errors with `No '<op>' operation for path: ...`.
+- Call `search_paths` first — action verbs are well-known.
+- Substitute a related entity's schema — `{Message, SaveToSentItems}` differs from a raw message.
+- Fall back to `web_fetch` against `learn.microsoft.com` — MCP or the action ref has the authoritative shape.
+
+## Schema availability ≠ operation allowed
+
+`get_schema` describes the OpenAPI shape the server **could** accept; it does NOT guarantee the operation is allowed at runtime. A successful schema response only means "if you POST/PATCH/GET this path with this body shape, the server will parse it" — the actual call may still 403 (missing scope, tenant policy) or 404 (path is action-only, or entity ID is stale).
+
+**Common trap — action-only entities returning an update schema:**
+- `get_schema({ "path": "/me/presence", "operationType": "update" })` returns a `microsoft.graph.presence` JSON Schema with writable-looking fields (`availability`, `activity`).
+- Calling `update_entity` on `/me/presence` returns **404 NotFound** — presence state is mutated via the `setPresence` / `setUserPreferredPresence` **action verbs**, not via PATCH on the entity.
+- The same pattern applies to other state-driven entities surfaced primarily through action verbs.
+
+**Rule:** when `search_paths` reports an action verb (`/me/presence/setPresence`, `/me/messages/{id}/send`, `/me/events/{id}/accept`) for a state change, route to `do_action` against that verb. Do NOT use the schema for the parent entity as license to `update_entity` — schema availability for `update` is a Graph metadata artifact, not a permission grant.
+

--- a/plugins/workiq-preview/skills/workiq-preview/references/mail-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/mail-work-iq.md
@@ -1,0 +1,85 @@
+# Mail (Outlook messages and folders)
+
+Use the WorkIQ **entity tools** for mail requests — listing/searching messages, reading folders,
+drafting/sending/replying/forwarding, marking read, copying/moving, and deleting. Use `ask` only
+for synthesis questions ("summarize the deadline thread with John"), not for finding,
+listing, or mutating individual messages.
+
+## Mail delta: prefer `/me/messages/delta` for full-mailbox sync
+
+For "sync my mail", "fetch the mail delta", or "give me mail changes" with **no folder named**,
+route `call_function` to `/me/messages/delta` — full mailbox in one cursor.
+`/me/mailFolders/{folderId}/delta` (e.g. `/me/mailFolders/inbox/delta`) is folder-scoped; use it
+only when the user names a folder.
+
+Paginate `@odata.nextLink` until you reach `@odata.deltaLink` (resume token for the next sync) —
+stopping at the first page is wrong.
+
+> **Always `call_function`, never `fetch`.** `delta` is an OData function. Calling
+> `/me/messages/delta` through `fetch` returns an `InvalidRequest` or wrong shape; route through
+> `call_function` with the function URL.
+
+## Finding a message by subject — use `$search`, not `$filter=contains`
+
+Graph rejects `$filter=contains(subject,'X')` and `$filter=startsWith(subject,'X')` on
+`/me/messages` with `InefficientFilter` **unless** the request carries the
+`ConsistencyLevel: eventual` header **plus** `$count=true` — and `fetch` does not expose
+request headers. `$filter=subject eq 'X'` requires an exact match (subjects with
+prefixes/suffixes silently return 0 results).
+
+**Use `$search` instead** — substring/word matching on subject and body, no extra headers,
+and it works with `update_entity` / `delete_entity` / `do_action` chains:
+
+- ✅ `fetch` `/me/messages?$search=%22Lockbox approval request%22&$top=5&$select=id,subject,from,receivedDateTime`
+- ❌ `fetch` `/me/messages?$filter=contains(subject,%27Lockbox%27)` → `InefficientFilter`
+- ❌ `fetch` `/me/messages?$filter=subject%20eq%20%27Lockbox%20approval%20request%27` → 0 results if subject has any suffix
+
+Quote the search phrase with `%22…%22` (URL-encoded double quotes) for phrase match; bare tokens
+do OR matching. Pair with `$top` to bound the result set when you need a single message id.
+
+For **mail folder name lookups** (`/me/mailFolders`), `$filter=displayName eq 'X'` is fine —
+folder names are exact-match by design. Use it for `rename` / `move` / `delete` folder chains.
+
+## Canonical paths
+
+| Operation | Tool | Path |
+|-----------|------|------|
+| List messages in Inbox | `fetch` | `/me/mailFolders/inbox/messages` |
+| Find a message by subject (substring) | `fetch` | `/me/messages?$search=%22subject phrase%22` |
+| Get a message by id | `fetch` | `/me/messages/{id}` |
+| Mark as read / change subject | `update_entity` | `/me/messages/{id}` with `{"isRead": true}` |
+| Send a draft you created | `do_action` | `/me/messages/{id}/send` |
+| Send a brand-new message in one shot | `do_action` | `/me/sendMail` |
+| Create a draft | `create_entity` | parentUrl `/me/messages` |
+| Create a reply / reply-all / forward draft | `create_entity` | `/me/messages/{id}/createReply`, `/createReplyAll`, `/createForward` |
+| Reply / forward immediately (no editable draft) | `do_action` | `/me/messages/{id}/reply`, `/replyAll`, `/forward` |
+| Copy / move to folder | `do_action` | `/me/messages/{id}/copy`, `/move` |
+| Delete (move to Deleted Items) | `delete_entity` | `/me/messages/{id}` |
+| Permanently delete (bypasses Deleted Items) | `do_action` | `/me/messages/{id}/permanentDelete` |
+| List folders | `fetch` | `/me/mailFolders` |
+| Find a folder by name | `fetch` | `/me/mailFolders?$filter=displayName eq 'Specs'` |
+| Mail delta (no folder) | `call_function` | `/me/messages/delta` |
+| Mail delta (folder-scoped) | `call_function` | `/me/mailFolders/inbox/messages/delta` |
+
+## "Draft" vs "send" — pick the right verb
+
+When the user says **"draft an email"**, **"compose a reply"**, **"prepare a response"**, or any
+variant asking the draft to **exist** (not just suggest wording), call `create_entity` to POST:
+
+- Fresh draft → `/me/messages`
+- Reply / reply-all / forward → `/me/messages/{id}/createReply`, `/createReplyAll`, `/createForward`
+
+These create persisted drafts the user can open in Outlook. **Generating draft text inline
+does NOT satisfy the request** — the user can't open it in Outlook.
+
+`do_action` `/reply`, `/replyAll`, `/forward`, `/sendMail` all send **immediately** — never use
+those when the user asked for a draft.
+
+## Resolve-then-act (do not loop)
+
+1. Resolve the message with **one** `fetch` (filter by `$search` for subject, or by `id`).
+2. If the first fetch misses, try **one** `ask` to locate it semantically.
+3. If still not found, **stop and report "not found"** — do not fire 10+ more
+   `fetch`/`search_paths`/`ask` calls.
+4. Once you have the id, call the mutation directly. Finding the message is not the goal;
+   performing the requested action is.

--- a/plugins/workiq-preview/skills/workiq-preview/references/search-paths-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/search-paths-work-iq.md
@@ -1,31 +1,24 @@
 # search_paths
 
-Discover available WorkIQ API paths by searching with a regex filter. Use this as the first step when you need to work with entity tools but aren't sure what paths are available for a given resource type.
+Discover available WorkIQ API paths by regex. Use as the first step before entity tools when the path is unknown.
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `filter` | string | No | Regex pattern to match against available paths (e.g., `messages`, `.*calendar.*`). Omit to list all paths. |
-| `backend` | string | No | Which backend to search: `graph-v1` (default), `sharepoint-rest`, or `dataverse` |
+| `filter` | string | Yes | Regex pattern (e.g., `messages`, `.*calendar.*`). Empty or missing filter is rejected by the current server — pass `.*` to enumerate everything. |
 
-> **⚠️ Stay on the default backend for M365 core data.** All mail, calendar, contacts, tasks,
-> people, Teams, and files paths live in `graph-v1` (the default). Only pass
-> `backend: "sharepoint-rest"` or `backend: "dataverse"` when the user explicitly targets those
-> systems. If a non-default backend search errors or returns nothing, **do not** retry other
-> backends hunting for core M365 data — it is not there.
+> **⚠️ One catalog only.** `search_paths` enumerates the single WorkIQ path catalog (Microsoft Graph paths). There is no `backend` / `source` / `provider` parameter — do not pass one, do not fabricate one from general knowledge. If the user asks about SharePoint REST, Dataverse, or any other API surface, say WorkIQ surfaces Graph paths through `search_paths` and report that the other surface is not available here.
 
-## When to Use
+## Workflow
 
-- Before using `fetch`, `create_entity`, or other entity tools when you're unsure of the exact path
-- To discover what data is accessible for a given concept (e.g., "what calendar-related paths exist?")
-- To explore the SharePoint REST or Dataverse backends (only when the user asks about those systems)
+1. `search_paths` with a broad filter to find candidate paths
+2. `get_schema` on the chosen path
+3. `fetch` or the appropriate write tool (`create_entity` / `update_entity` / `delete_entity` / `do_action` / `call_function`)
 
-## Recommended Workflow
+If the user asks to discover paths AND read or mutate, continue to the mutation tool after picking the path — discovery alone is incomplete.
 
-1. Call `search_paths` with a broad filter to find candidate paths
-2. Call `get_schema` on the path you want to use to understand its fields and parameters
-3. Call `fetch` or the appropriate write tool with the confirmed path
+Never answer API/path questions from general Graph knowledge, local SQL, filesystem search, or built-in tools. Summarize paths from `search_paths`; if none matched, say WorkIQ did not confirm one.
 
 ## Examples
 
@@ -39,14 +32,9 @@ Discover available WorkIQ API paths by searching with a regex filter. Use this a
 { "filter": ".*calendar.*" }
 ```
 
-### List all available paths (no filter)
+### Enumerate every path
 ```json
-{}
-```
-
-### Search SharePoint REST paths
-```json
-{ "backend": "sharepoint-rest" }
+{ "filter": ".*" }
 ```
 
 ### Find Planner paths

--- a/plugins/workiq-preview/skills/workiq-preview/references/troubleshooting.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting WorkIQ
 
-Use this reference when a WorkIQ tool call fails, returns an unexpected error, or behaves differently than the documentation suggests. Resolve the issue here before retrying or falling back to a different approach.
+Use this reference when a WorkIQ tool call fails or behaves unexpectedly.
 
 ## Both `workiq` and `workiq-preview` installed side-by-side
 
@@ -69,7 +69,7 @@ copilot plugin install workiq@microsoft
 
 ## Entity tool returns "not enabled" or "experimental feature disabled"
 
-**Symptom:** Calls to `search_paths`, `fetch`, `get_schema`, `create_entity`, `update_entity`, `delete_entity`, `do_action`, `call_function`, `fetch_blob`, or `upload_blob` fail with an error indicating the feature is not enabled or is experimental.
+**Symptom:** Calls to `search_paths`, `fetch`, `get_schema`, `create_entity`, `update_entity`, `delete_entity`, `do_action`, or `call_function` fail with an error indicating the feature is not enabled or is experimental.
 
 **Cause:** Entity tools are gated behind an experimental flag in the WorkIQ CLI configuration.
 
@@ -80,27 +80,6 @@ workiq config set experimental=true
 ```
 
 After enabling, retry the original tool call.
-
-## Tool call fails with a `null` / empty response and no error details
-
-**Symptom:** A WorkIQ tool call fails but the response is literally `null` — no status code, no error body, no diagnostic of any kind.
-
-**Cause:** Some backend failures (permission denials, unsupported paths, policy blocks, timeouts) are currently surfaced as a bare `null` response instead of an error message.
-
-**Fix / how to proceed:**
-
-1. Check the request itself first — URL format rules (server-relative path, URL-encoded query values), `jsonBody` string encoding, and that the path/ID is real (no `{id}` literals, no guessed IDs). Fix and retry **once**.
-2. If a multi-URL `fetch` failed, retry the URLs individually — one bad URL can fail the batch.
-3. If it still fails, **stop retrying**. Do not probe many path variants, other backends, or alternative APIs hunting for a way around it.
-4. **Report it honestly:** tell the user which call failed and that the server returned no diagnostic detail. You may suggest possible causes (missing Graph scopes — see the 403 entry below for `workiq auth consent`; unsupported path) only as explicitly unconfirmed hypotheses. **Never state a specific status code or error ("403", "AccessDenied", "Insufficient privileges") that you did not actually observe in a tool response.**
-
-## `search_paths` fails with "internal error" on `sharepoint-rest` / `dataverse`
-
-**Symptom:** `search_paths` with `backend: "sharepoint-rest"` or `backend: "dataverse"` fails with "An internal error occurred while searching paths."
-
-**Cause:** Non-default backends may be unavailable in your environment. They are never needed for core M365 data — mail, calendar, contacts, tasks, people, Teams, and files all live in the default `graph-v1` backend.
-
-**Fix:** Drop the `backend` parameter and search `graph-v1`. Only use the other backends when the user explicitly targets SharePoint REST or Dataverse, and report it if they're unavailable.
 
 ## Entity tool returns a 400 / "bad request" on a Graph URL
 
@@ -115,11 +94,46 @@ After enabling, retry the original tool call.
 
 See the **URL Format Rules** section of `SKILL.md` for full examples.
 
+## Tool call fails with a `null` / empty response and no error details
+
+**Symptom:** A WorkIQ tool call fails but the response is literally `null` — no status code, no error body, no diagnostic of any kind.
+
+**Cause:** Some backend failures (permission denials, unsupported paths, policy blocks, timeouts) are currently surfaced as a bare `null` response instead of an error message.
+
+**Fix / how to proceed:**
+
+1. Check the request itself first — URL format rules (server-relative path, URL-encoded query values), `jsonBody` string encoding, and that the path/ID is real (no `{id}` literals, no guessed IDs). Fix and retry **once**.
+2. If a multi-URL `fetch` failed, retry the URLs individually — one bad URL can fail the batch.
+3. If it still fails, **stop retrying**. Do not probe many path variants, other backends, or alternative APIs hunting for a way around it.
+4. **Report it honestly:** tell the user which call failed and that the server returned no diagnostic detail. You may suggest possible causes (missing Graph scopes — see the 403 entry below for `workiq auth consent`; unsupported path) only as explicitly unconfirmed hypotheses. **Never state a specific status code or error ("403", "AccessDenied", "Insufficient privileges") that you did not actually observe in a tool response.**
+
+## `search_paths` rejects a `backend` / `source` / `provider` argument
+
+**Symptom:** `search_paths` returns a tool input validation error, or silently ignores extra arguments like `backend: "sharepoint-rest"` / `provider: "dataverse"`.
+
+**Cause:** `search_paths` only accepts `filter` (regex, required) and `agentId` (optional). There is no `backend` parameter and no equivalent — WorkIQ exposes a single catalog of Microsoft Graph paths.
+
+**Fix:** Drop the extra argument and retry with `filter` only. If the user explicitly asked for SharePoint REST, Dataverse, or any other API surface, report honestly that WorkIQ surfaces Graph paths through `search_paths` and the other surface is not available here. Do not invent a tool variant or alternate backend.
+
+## `fetch_blob` or `upload_blob` returns "tool does not exist"
+
+**Symptom:** A call to `fetch_blob`, `upload_blob`, or any variant (e.g. `download_file`, `get_blob`, `put_file`) returns "tool does not exist" — or you cannot find such a tool in your available-tools list.
+
+**Cause:** This skill does **not** expose binary-content tools. The only available tools are `ask`, `list_agents`, `search_paths`, `get_schema`, `fetch`, `call_function`, `create_entity`, `update_entity`, `delete_entity`, and `do_action`. See the deny rule in `SKILL.md`.
+
+**Fix:** Do not retry, do not search for an alternate binary tool, do not invent one.
+
+- For downloads: `fetch` the item's metadata (`/me/drive/items/{id}`) and return the `webUrl` so the user can open and download in OneDrive / SharePoint / Outlook directly.
+- For uploads: tell the user this skill cannot send file bytes; offer them the destination URL so they can upload via the OneDrive / SharePoint UI.
+- For attachments: return the parent message URL so the user can open and download in Outlook.
+
+Never fabricate base64 content or `@microsoft.graph.downloadUrl` values to satisfy the request.
+
 ## `ask` is slow or appears to hang
 
-**Symptom:** A single call to `ask` takes anywhere from 10 seconds to a few minutes.
+**Symptom:** A single call to `ask` takes 10–30 seconds.
 
-**Cause:** Expected behavior. `ask` is agentic — it performs multiple backend searches internally. Typical calls run 10–60 seconds; broad questions take longer.
+**Cause:** Expected behavior. `ask` is agentic — it performs multiple backend searches internally.
 
 **Fix:** If you only need a literal list, filter, or known entity, use `fetch` (or another entity tool) instead. Entity tools typically return in under a second.
 
@@ -155,11 +169,19 @@ Then retry the failing tool call or run `workiq auth consent` again.
 
 ## HTTP 403 Forbidden on an entity tool call
 
-**Symptom:** `fetch`, `do_action`, or another entity tool returns `HTTP 403 Forbidden` for a Graph path (e.g., `/me/calendars`, `/me/events`, `/me/messages`).
+**Symptom:** `fetch`, `do_action`, `update_entity`, or another entity tool returns `HTTP 403` for a Graph path. Two common flavors:
 
-**Cause:** The current user (or app) has not yet consented to the Microsoft Graph permission scopes needed for that path. By default, WorkIQ only requests a minimal set of scopes; additional scopes must be granted explicitly.
+1. **Missing delegated scope** — error body contains `"Missing scope permissions on the request. API requires one of '<Scope.Name>, ...'"`. Typical examples: editing a channel message requires `ChannelMessage.ReadWrite`; reading another user's calendar requires `Calendars.Read.Shared`.
+2. **Insufficient directory privileges** — error body contains `"code":"Authorization_RequestDenied","message":"Insufficient privileges to complete the operation."`. Typical examples: `PATCH /me` to change `jobTitle`, `department`, `officeLocation`, `manager`, or any other directory-managed property -- these are read-only via delegated `/me` scopes and only an admin can write them through the directory.
 
-**Fix:** Run the `workiq auth consent` command to grant the required scopes, then retry the tool call. For example:
+**Cause:** The current user (or app) does not have the Microsoft Graph permission needed for that operation. By default, WorkIQ only requests a minimal set of scopes; additional scopes must be granted explicitly, and some properties cannot be written by end users at all.
+
+**Do not retry.** A 403 from Graph is **permanent** until consent is granted (or the operation is performed by an admin). Repeating the exact same call returns the exact same 403. The model must stop after the first 403, surface the failure to the user, and either:
+
+- Tell the user the operation isn't permitted with the current consent and suggest the appropriate `workiq auth consent` command (flavor 1), or
+- Tell the user the property is directory-managed and an administrator change is required (flavor 2).
+
+**Fix (flavor 1 only):** Run `workiq auth consent` to grant the missing scope, then retry once.
 
 ```powershell
 # Grant calendar read access
@@ -167,6 +189,11 @@ workiq auth consent --scopes Calendars.Read
 
 # Grant multiple scopes at once
 workiq auth consent --scopes Mail.Read Calendars.ReadWrite Sites.Read.All
+
+# Channel message editing
+workiq auth consent --scopes ChannelMessage.ReadWrite
 ```
+
+Flavor 2 (`Authorization_RequestDenied` on `/me` directory writes) is **not** fixable by `workiq auth consent` for an end user -- a tenant admin must update the property via the directory.
 
 

--- a/plugins/workiq-preview/skills/workiq-preview/references/update-entity-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/update-entity-work-iq.md
@@ -1,41 +1,35 @@
 # update_entity
 
-Update an existing WorkIQ entity via HTTP PATCH. Only the fields you include in the body are changed — other fields are left untouched.
+PATCH an existing WorkIQ entity. Only fields in the body are changed; other fields are untouched.
 
 ## Parameters
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `entityUrl` | string | Yes | The entity path including the item's ID (e.g., `/me/events/{id}`). Get the ID from a prior `fetch` or `create_entity` call. Must be relative to the domain root — start with `/`, do not include a scheme or authority (`https://graph.microsoft.com` ❌, `/me/events/{id}` ✅). URL-encode any special characters in path segments. |
-| `jsonBody` | string | Yes | JSON-encoded string containing only the fields to update. Omit fields you don't want to change. |
+| `entityUrl` | string | Yes | Entity path including ID (`/me/events/{id}`). Get the ID from `fetch` or `create_entity`. Server-relative, starts with `/`, no scheme. URL-encode special characters. |
+| `jsonBody` | object \| string | Yes | Fields to update, supplied as a JSON object (`{"isRead":true}`) or a JSON-encoded string. Omit fields you don't want to change. |
+| `headers` | object | No | Optional HTTP request headers. If the operation's schema declares an `If-Match` header parameter, you MUST set it to the `@odata.etag` value from the latest read of the same entity. |
 
 ## When to Use
 
-- Marking an email as read/unread
-- Updating the subject, time, or location of a calendar event
-- Changing the status or due date of a task
-- Updating a document's metadata
+- Mark email read/unread
+- Update event subject, time, location
+- Change task status or due date
+- Update document metadata
 - Any partial update to an existing M365 entity
 
 ## Gotchas
 
-- **`entityUrl` must address exactly one entity by ID.** A collection or query URL
-  (`/me/planner/tasks?$filter=startswith(title,'...')`) is rejected with
-  "Write requests are only supported on contained entities" — resolve the ID with
-  `fetch` first, then PATCH `/.../{id}`.
-- The ID must come from a real tool response for the **same entity type** — a directory user ID
-  does not work on `/me/contacts/{id}`, and an ID scraped from a search-result URL is not an
-  entity ID.
-- Updating one entity means one PATCH. If it fails, fix the request and retry once or twice —
-  do not loop the same PATCH or fan it out across other entities.
-- **Planner writes need an `If-Match` etag** — fetch the task first; on a 412/precondition
-  error, re-fetch and retry (see `references/tasks-work-iq.md`).
+- **`entityUrl` must address exactly one entity by ID.** A collection or query URL (`/me/planner/tasks?$filter=startswith(title,'...')`) is rejected with "Write requests are only supported on contained entities" — resolve the ID with `fetch` first, then PATCH `/.../{id}`.
+- The ID must come from a real tool response for the **same entity type** — a directory user ID does not work on `/me/contacts/{id}`, and an ID scraped from a search-result URL is not an entity ID.
+- Updating one entity means one PATCH. If it fails, fix the request and retry once or twice — do not loop the same PATCH or fan it out across other entities.
+- **Planner writes need an `If-Match` etag** — fetch the task first; on a 412/precondition error, re-fetch and retry (see `references/tasks-work-iq.md`).
 
 ## Workflow
 
-1. Obtain the entity's `id` from `fetch` or `create_entity`
-2. Optionally call `get_schema` with `httpMethod: "patch"` to confirm which fields are updatable
-3. Call `update_entity` with only the fields you want to change
+1. Get the entity's `id` from `fetch` or `create_entity`
+2. (Optional) `get_schema` with `operationType: "update"` to confirm updatable fields
+3. `update_entity` with only the fields to change
 
 ## Examples
 
@@ -78,3 +72,15 @@ Update an existing WorkIQ entity via HTTP PATCH. Only the fields you include in 
   "jsonBody": "{\"categories\":[\"Project Alpha\"]}"
 }
 ```
+
+## Common failures (do not retry)
+
+`update_entity` failures from Microsoft Graph are almost always permanent on the same payload. **Do not retry the same call** after any of these -- repeated identical PATCHes return the exact same error.
+
+| HTTP / code | Meaning | Action |
+|---|---|---|
+| `403` + `"Missing scope permissions"` | The signed-in user has not consented to the Graph scope this PATCH needs (e.g. `ChannelMessage.ReadWrite` for editing channel messages, `Mail.ReadWrite` for marking mail). | Stop. Tell the user the consent is missing and suggest `workiq auth consent --scopes <Scope>`. See [`troubleshooting.md`](troubleshooting.md#http-403-forbidden-on-an-entity-tool-call). |
+| `403` + `"Authorization_RequestDenied"` + `"Insufficient privileges"` on `/me` | Directory-managed property (`jobTitle`, `department`, `officeLocation`, `manager`, etc.) is read-only via delegated `/me` scopes. End users cannot change these even with extra consent. | Stop. Tell the user the property is directory-managed and an admin change is required. **Do not call `workiq auth consent` -- it will not help.** |
+| `400` with field name | The field is not in the PATCH-able set for that entity (e.g. computed/read-only) or value type is wrong. | Stop. Re-read [`get_schema`](get-schema-work-iq.md) for the writable-field list before reissuing. |
+| `404` | The entity ID is stale / wrong / from a different mailbox. | Stop. Re-`fetch` to get the current ID; do not retry the same URL. |
+

--- a/plugins/workiq-preview/skills/workiq-preview/references/upload-blob-work-iq.md
+++ b/plugins/workiq-preview/skills/workiq-preview/references/upload-blob-work-iq.md
@@ -1,5 +1,7 @@
 # upload_blob
 
+> ⚠️ **Not released yet.** `upload_blob` is documented here for future reference but is **not part of the current preview MCP surface**. Calling it from this preview build returns `tool does not exist`. When a user asks to upload a local file today, tell them this preview build can't accept raw byte payloads yet and ask them to upload through the OneDrive / SharePoint web UI — see the [Binary file content](../SKILL.md) section in `SKILL.md`.
+
 Upload a local file to a WorkIQ path via HTTP PUT. Use this to upload files to OneDrive or SharePoint.
 
 ## Parameters


### PR DESCRIPTION
## Summary

Documentation-only changes for the `workiq-preview` plugin skill, motivated by results from an internal MCP tool-routing evaluation suite (Microsoft 365 prod tenant, gpt-5.5, plugin mode). Compared to the prior run on the same suite the new guidance lifts overall pass rate **39.2% -> 58.7%**, with `mcp_result_quality` 4.27 -> 4.66 and `answer_quality` 4.36 -> 4.67. `path_accuracy` holds flat (3.71 -> 3.68) while the tools are returning materially more useful evidence and the final answers track that evidence more honestly.

### Changes

- **`.mcp.json`** now points at the hosted WorkIQ preview prod MCP endpoint: `https://workiq.svc.cloud.microsoft/mcp`. This replaces the previous local `npx -y @microsoft/workiq@preview mcp` stdio startup so the packaged plugin connects directly to the released preview MCP service.

- **`SKILL.md`** (276 -> 384 lines)
  - Tightened `ask` vs direct-entity heuristics (single-entity projection questions like "show me X on event Y" should `fetch`, not `ask`).
  - Added explicit mail-folder routing cues so prompts about `"the X folder"` no longer fall through to OneDrive/SharePoint searches.
  - Clarified delta change-tracking ("what's new since...") via `call_function`.
  - **Reworded the binary-content deny rule** from "this skill excludes `fetch_blob` / `upload_blob`" to "they are not part of the current preview MCP surface (not released yet)". The rule still tells the model to return `webUrl` and never invent base64 payloads, but the framing matches reality -- the underlying tools exist, they're just not enabled for this preview build today.

- **New reference: `references/mail-work-iq.md`**
  - Mail-folder vs OneDrive-folder disambiguation.
  - `search` vs `filter` guidance for subject lookups -- Graph rejects `filter=contains(subject,...)` without the `ConsistencyLevel: eventual` + `count=true` header pair, which `fetch` cannot supply, so it silently returns empty.
  - Worked examples for rename / move / mark-read flows.

- **Reference updates** (per-tool clarifications, tighter examples, removed stale guidance):
  `ask-work-iq.md`, `call-function-work-iq.md`, `create-entity-work-iq.md`, `delete-entity-work-iq.md`, `do-action-work-iq.md`, `fetch-work-iq.md`, `get-schema-work-iq.md`, `search-paths-work-iq.md`, `troubleshooting.md`, `update-entity-work-iq.md`.

- **`fetch-blob-work-iq.md` and `upload-blob-work-iq.md`** are **kept** and each leads with a "**Not released yet**" banner. The two tools are not in the current preview MCP surface -- calling them returns `tool does not exist`. The banner makes the status discoverable to readers and steers them at the SKILL.md `webUrl` workflow, without removing the parameter / schema reference for future enablement.

### Scope

No changes to `README.md`, `.github/plugin/plugin.json`, `.claude-plugin/`, `.codex-plugin/`, `marketplace.json`, or any non-skill reference outside this plugin. Frontmatter `name` / `description` are unchanged so existing plugin-discovery / activation triggers are preserved.
