### PR TITLE
Fix broken VS Code MCP install badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ You: Find documents I worked on yesterday
 
 ## 📦 Alternative: Standalone MCP Installation
 
-[![Install in VS Code](https://img.shields.io/badge/VS_Code-Install_Server-0098FF?style=flat-square&logo=visualstudiocode&logoColor=white)](https://vscode.dev/redirect/mcp/install?name=workiq&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%7D)
-[![Install in VS Code Insiders](https://img.shields.io/badge/VS_Code_Insiders-Install_Server-24bfa5?style=flat-square&logo=visualstudiocode&logoColor=white)](https://insiders.vscode.dev/redirect/mcp/install?name=workiq&config=%7B%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40microsoft%2Fworkiq%22%2C%22mcp%22%5D%7D&quality=insiders)
+[<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522workiq%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522-y%2522%252C%2522%2540microsoft%252Fworkiq%2522%252C%2522mcp%2522%255D%257D) [<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522workiq%2522%252C%2522command%2522%253A%2522npx%2522%252C%2522args%2522%253A%255B%2522-y%2522%252C%2522%2540microsoft%252Fworkiq%2522%252C%2522mcp%2522%255D%257D)
 
 If you prefer to run WorkIQ as a standalone MCP server:
 


### PR DESCRIPTION
## Problem

The "Install in VS Code" and "Install in VS Code Insiders" badge buttons in the README return **HTTP 400** when clicked.

The old redirect format `vscode.dev/redirect/mcp/install?name=...&config=...` is no longer supported.

## Fix
<img width="1122" height="583" alt="image" src="https://github.com/user-attachments/assets/ef283f8e-0679-440f-9b0e-231122c315d7" />

Updated to the current redirect format used by [Playwright MCP](https://github.com/microsoft/playwright-mcp) and other Microsoft MCP servers:

```
insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F...
```

Also updated badge images to match the current shields.io format (the old `logo=visualstudiocode` slug no longer renders an icon).

## Verification

- Old URL → HTTP 400 ❌
- New URL → 302 redirect to `vscode:mcp/install?{...}` ✅
- Matches the format used by `@playwright/mcp` README