### PR TITLE
Route agent/plugin build and publish intents to wiqd

### DIFF
--- a/plugins/workiq/README.md
+++ b/plugins/workiq/README.md
@@ -92,7 +92,7 @@ iex "& { $(irm 'https://aka.ms/wiqd/install.ps1') }"
 curl -fsSL https://aka.ms/wiqd/install.sh | bash
 ```
 
-Restart Copilot CLI after installing so the `wiqd` plugin and its skill load, then continue with `copilot -i "create a new declarative agent" --agent wiqd:wiqd`. See [`references/wiqd.md`](./skills/workiq/references/wiqd.md).
+Reload skills afterwards (`/skills reload`, or reload your Copilot window) and re-send your request in the same session — the `wiqd` skill takes it from there. See [`references/wiqd.md`](./skills/workiq/references/wiqd.md).
 
 ## Skills
 

--- a/plugins/workiq/README.md
+++ b/plugins/workiq/README.md
@@ -78,6 +78,22 @@ The plugin exposes the WorkIQ MCP tool surface — read **and** write — from `
 
 > ⚠️ `upload_blob` is documented for future reference but is not released in the current WorkIQ MCP surface. For uploads, direct the user to OneDrive / SharePoint until raw byte upload support is released.
 
+### Building or publishing an agent or plugin → `wiqd`
+
+WorkIQ covers Microsoft 365 **data**, not the Copilot extensibility **pipeline**. Requests like "create a declarative agent", "validate my agent", "deploy my plugin", or "publish to AppSource" are handed off to **Work IQ Dev Tools (`wiqd`)**. The skill checks whether `wiqd` is already available, installs it with the official script if not, and then points you at the `wiqd` skill:
+
+```powershell
+# Windows
+iex "& { $(irm 'https://aka.ms/wiqd/install.ps1') }"
+```
+
+```bash
+# macOS / Linux
+curl -fsSL https://aka.ms/wiqd/install.sh | bash
+```
+
+Restart Copilot CLI after installing so the `wiqd` plugin and its skill load, then continue with `copilot -i "create a new declarative agent" --agent wiqd:wiqd`. See [`references/wiqd.md`](./skills/workiq/references/wiqd.md).
+
 ## Skills
 
 | Skill | Description |

--- a/plugins/workiq/README.md
+++ b/plugins/workiq/README.md
@@ -80,7 +80,9 @@ The plugin exposes the WorkIQ MCP tool surface — read **and** write — from `
 
 ### Building or publishing an agent or plugin → `wiqd`
 
-WorkIQ covers Microsoft 365 **data**, not the Copilot extensibility **pipeline**. Requests like "create a declarative agent", "validate my agent", "deploy my plugin", or "publish to AppSource" are handed off to **Work IQ Dev Tools (`wiqd`)**. The skill checks whether `wiqd` is already available, installs it with the official script if not, and then points you at the `wiqd` skill:
+WorkIQ covers Microsoft 365 **data**, not the Copilot extensibility **pipeline**. Requests like "create a declarative agent", "validate my agent", "deploy my plugin", or "publish to AppSource" are handed off to **Work IQ Dev Tools (`wiqd`)**. The skill checks whether `wiqd` is already available and, if not, **asks you to confirm before installing anything**:
+
+> ⚠️ **Preview.** Work IQ Dev Tools is a preview experience — commands and behavior may change, and some capabilities are gated or incomplete.
 
 ```powershell
 # Windows

--- a/plugins/workiq/README.md
+++ b/plugins/workiq/README.md
@@ -80,7 +80,7 @@ The plugin exposes the WorkIQ MCP tool surface — read **and** write — from `
 
 ### Building or publishing an agent or plugin → `wiqd`
 
-WorkIQ covers Microsoft 365 **data**, not the Copilot extensibility **pipeline**. Requests like "create a declarative agent", "validate my agent", "deploy my plugin", or "publish to AppSource" are handed off to **Work IQ Dev Tools (`wiqd`)**. The skill checks whether `wiqd` is already available and, if not, **asks you to confirm before installing anything**:
+WorkIQ covers Microsoft 365 **data**, not the Copilot extensibility **pipeline**. Requests like "create a declarative agent", "validate my agent", "deploy my plugin", or "publish to AppSource" are handed off to **Work IQ Dev Tools (`wiqd`)**. The skill checks whether `wiqd` is already available and, if not, **asks you to confirm first — then runs the installer for you**:
 
 > ⚠️ **Preview.** Work IQ Dev Tools is a preview experience — commands and behavior may change, and some capabilities are gated or incomplete.
 

--- a/plugins/workiq/skills/workiq/SKILL.md
+++ b/plugins/workiq/skills/workiq/SKILL.md
@@ -138,13 +138,13 @@ WorkIQ **reads and writes M365 data**. It does **not** build, package, deploy, o
 
 **Handoff procedure — read `references/wiqd.md` before acting.** In short:
 
-1. **Check first.** If a `wiqd` skill or `wiqd:wiqd` agent is already loaded, or `wiqd --version` succeeds, **do not install** — go to step 3.
+1. **Check first.** If the `wiqd` skill is already loaded, or `wiqd --version` succeeds, **do not install** — go to step 3.
 2. **Install with the official script only** (confirm with the user first):
    - Windows: `iex "& { $(irm 'https://aka.ms/wiqd/install.ps1') }"`
    - macOS/Linux: `curl -fsSL https://aka.ms/wiqd/install.sh | bash`
 
-   This installs the `wiqd` CLI, the VS Code extension, and the **Copilot CLI plugin that provides the `wiqd` skill**. Never use a repo-local or hand-rolled install script.
-3. **Guide the user to the skill.** A freshly installed plugin isn't active in the current session — tell the user to **restart Copilot CLI**, then continue via the skill or `copilot -i "<their request>" --agent wiqd:wiqd`. If the `wiqd` skill is already loaded, invoke it directly instead of sending the user away.
+   This installs the `wiqd` CLI, the VS Code extension, and the plugin that provides the **`wiqd` skill**. Never use a repo-local or hand-rolled install script.
+3. **Reload skills and continue here.** The new skill isn't loaded yet — ask the user to run `/skills reload` (or reload their Copilot window), then re-send their request in this same session. Once the `wiqd` skill is available, invoke it directly and carry the request through. Never send the user to a separate session or a different entry point.
 
 > ❌ **Do not** hand-author `declarativeAgent.json` / `manifest.json` / a Teams app package yourself, and **do not** try to deploy or publish an agent through WorkIQ MCP tools — no such path exists.
 

--- a/plugins/workiq/skills/workiq/SKILL.md
+++ b/plugins/workiq/skills/workiq/SKILL.md
@@ -58,7 +58,7 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 | What's new/changed/removed since a point in time | "What's new in my Inbox since this morning?", "What's changed on my calendar since yesterday?", "What's been added to my contacts recently?" | `call_function` (delta — `/me/mailFolders/inbox/messages/delta`, `/me/calendarView/delta?...`, `/me/contacts/delta`). **Never call delta via `fetch`** — see `references/call-function-work-iq.md` |
 | Sending mail, accepting/declining meetings | "Send this draft", "Accept the 2pm meeting" | `do_action` |
 | Creating a calendar event, draft, or task | "Create a calendar event Friday at 3pm" | `create_entity` |
-| **Building/deploying/publishing a Copilot agent or plugin** | "Create a declarative agent", "publish my agent", "deploy my plugin" | **Not WorkIQ** — hand off to `wiqd`, see `references/wiqd.md` |
+| Building/deploying/publishing a Copilot agent or plugin | "Create a declarative agent", "publish my agent", "deploy my plugin" | hand off to `wiqd` — see `references/wiqd.md` |
 
 **DO NOT say "I don't have access to emails/meetings/messages"** - use WorkIQ instead!
 

--- a/plugins/workiq/skills/workiq/SKILL.md
+++ b/plugins/workiq/skills/workiq/SKILL.md
@@ -141,7 +141,7 @@ WorkIQ **reads and writes M365 data**. It does **not** build, package, deploy, o
 **Handoff procedure — read `references/wiqd.md` before acting.** In short:
 
 1. **Check first.** If the `wiqd` skill is already loaded, or `wiqd --version` succeeds, **do not install** — go to step 3.
-2. **🛑 Ask the user to confirm before installing — hard gate.** Never install on your own initiative; the build request is not consent. Tell them `wiqd` is missing, that it's a **preview** experience, what the installer adds (`wiqd` CLI + M365 Agents Toolkit dependency, VS Code extension, plugin providing the `wiqd` skill), and the exact command. Proceed **only** on an explicit yes — silence or ambiguity is not consent. If they decline, stop and say the request can't proceed without `wiqd`; don't work around it. Then install with the official script only:
+2. **🛑 Ask the user to confirm, then run the install yourself — hard gate.** Never install on your own initiative; the build request is not consent. Tell them `wiqd` is missing, that it's a **preview** experience, what the installer adds (`wiqd` CLI + M365 Agents Toolkit dependency, VS Code extension, plugin providing the `wiqd` skill), and the exact command you'll run. Proceed **only** on an explicit yes — silence or ambiguity is not consent. If they decline, stop and say the request can't proceed without `wiqd`; don't work around it. Once confirmed, **execute the command yourself** (don't make the user run it) using the official script only:
    - Windows: `iex "& { $(irm 'https://aka.ms/wiqd/install.ps1') }"`
    - macOS/Linux: `curl -fsSL https://aka.ms/wiqd/install.sh | bash`
 

--- a/plugins/workiq/skills/workiq/SKILL.md
+++ b/plugins/workiq/skills/workiq/SKILL.md
@@ -121,12 +121,6 @@ Common failure: fetching the entity and stopping, asking the user "did you want 
 - **Call at least one WorkIQ tool before answering any M365 question.** Exceptions: non-workplace questions, or questions about this skill's docs.
 - **Honor paging.** If a response includes `@odata.nextLink`, do not present the first page as complete. Continue fetching when the user asks for all/every/complete, or say the answer is partial.
 
-### Building, deploying, or publishing an agent or plugin → `wiqd`
-
-WorkIQ reads and writes M365 **data**; it does not build, package, deploy, or publish Copilot agents or plugins. When the user wants to create/scaffold, edit, validate/evaluate, provision/deploy/share, package/publish/onboard, or monitor an **agent or plugin**, that belongs to Work IQ Dev Tools (`wiqd`) — **read `references/wiqd.md` and follow it** (intent detection, the install confirmation gate, and the handoff). Do not hand-author agent manifests or attempt deployment through WorkIQ tools.
-
-This does **not** apply to M365 data requests, to "agent" meaning this assistant, or to installing a plugin from this marketplace — those stay in WorkIQ.
-
 ### Don't substitute web search or CLI introspection
 
 - ❌ `web_fetch` / web search **as the first move** for Graph or M365. WorkIQ is the source of truth — call `get_schema` (for fields) or `search_paths` (for endpoints) first. `web_fetch` is a fallback **only after** WorkIQ returns no useful result.

--- a/plugins/workiq/skills/workiq/SKILL.md
+++ b/plugins/workiq/skills/workiq/SKILL.md
@@ -125,6 +125,8 @@ Common failure: fetching the entity and stopping, asking the user "did you want 
 
 WorkIQ **reads and writes M365 data**. It does **not** build, package, deploy, or publish Copilot agents or plugins. Those requests belong to **Work IQ Dev Tools (`wiqd`)**.
 
+> ⚠️ **Preview.** `wiqd` is a preview experience — commands and behavior may change, and some capabilities are gated or incomplete. Say so before installing.
+
 **Route to `wiqd` when the user wants to:**
 
 | Intent | Example phrasings |
@@ -139,7 +141,7 @@ WorkIQ **reads and writes M365 data**. It does **not** build, package, deploy, o
 **Handoff procedure — read `references/wiqd.md` before acting.** In short:
 
 1. **Check first.** If the `wiqd` skill is already loaded, or `wiqd --version` succeeds, **do not install** — go to step 3.
-2. **Install with the official script only** (confirm with the user first):
+2. **🛑 Ask the user to confirm before installing — hard gate.** Never install on your own initiative; the build request is not consent. Tell them `wiqd` is missing, that it's a **preview** experience, what the installer adds (`wiqd` CLI + M365 Agents Toolkit dependency, VS Code extension, plugin providing the `wiqd` skill), and the exact command. Proceed **only** on an explicit yes — silence or ambiguity is not consent. If they decline, stop and say the request can't proceed without `wiqd`; don't work around it. Then install with the official script only:
    - Windows: `iex "& { $(irm 'https://aka.ms/wiqd/install.ps1') }"`
    - macOS/Linux: `curl -fsSL https://aka.ms/wiqd/install.sh | bash`
 

--- a/plugins/workiq/skills/workiq/SKILL.md
+++ b/plugins/workiq/skills/workiq/SKILL.md
@@ -121,36 +121,11 @@ Common failure: fetching the entity and stopping, asking the user "did you want 
 - **Call at least one WorkIQ tool before answering any M365 question.** Exceptions: non-workplace questions, or questions about this skill's docs.
 - **Honor paging.** If a response includes `@odata.nextLink`, do not present the first page as complete. Continue fetching when the user asks for all/every/complete, or say the answer is partial.
 
-## 🚧 Building, deploying, or publishing an agent or plugin → hand off to `wiqd`
+### Building, deploying, or publishing an agent or plugin → `wiqd`
 
-WorkIQ **reads and writes M365 data**. It does **not** build, package, deploy, or publish Copilot agents or plugins. Those requests belong to **Work IQ Dev Tools (`wiqd`)**.
+WorkIQ reads and writes M365 **data**; it does not build, package, deploy, or publish Copilot agents or plugins. When the user wants to create/scaffold, edit, validate/evaluate, provision/deploy/share, package/publish/onboard, or monitor an **agent or plugin**, that belongs to Work IQ Dev Tools (`wiqd`) — **read `references/wiqd.md` and follow it** (intent detection, the install confirmation gate, and the handoff). Do not hand-author agent manifests or attempt deployment through WorkIQ tools.
 
-> ⚠️ **Preview.** `wiqd` is a preview experience — commands and behavior may change, and some capabilities are gated or incomplete. Say so before installing.
-
-**Route to `wiqd` when the user wants to:**
-
-| Intent | Example phrasings |
-|---|---|
-| Create / scaffold an agent or plugin | "create an agent", "new declarative agent", "scaffold a Copilot agent", "create a plugin", "new plugin project" |
-| Build / edit agent artifacts | "build my agent", "edit my agent", "add a capability", "add a knowledge source", "add an API plugin", "update the manifest" |
-| Validate / test / evaluate | "validate my agent", "run my evals", "test my agent", "debug my agent", "open devui" |
-| Provision / deploy / install / share | "provision my agent", "deploy my agent", "install my agent", "sideload my agent", "share my agent with my team" |
-| Package / publish / onboard | "package my agent", "publish my agent", "submit to AppSource", "publish to Partner Center", "onboard my agent", "start compliance review" |
-| Monitor a deployed agent | "monitor my agent", "check agent health", "talk to my deployed agent" |
-
-**Handoff procedure — read `references/wiqd.md` before acting.** In short:
-
-1. **Check first.** If the `wiqd` skill is already loaded, or `wiqd --version` succeeds, **do not install** — go to step 3.
-2. **🛑 Ask the user to confirm, then run the install yourself — hard gate.** Never install on your own initiative; the build request is not consent. Tell them `wiqd` is missing, that it's a **preview** experience, what the installer adds (`wiqd` CLI + M365 Agents Toolkit dependency, VS Code extension, plugin providing the `wiqd` skill), and the exact command you'll run. Proceed **only** on an explicit yes — silence or ambiguity is not consent. If they decline, stop and say the request can't proceed without `wiqd`; don't work around it. Once confirmed, **execute the command yourself** (don't make the user run it) using the official script only:
-   - Windows: `iex "& { $(irm 'https://aka.ms/wiqd/install.ps1') }"`
-   - macOS/Linux: `curl -fsSL https://aka.ms/wiqd/install.sh | bash`
-
-   This installs the `wiqd` CLI, the VS Code extension, and the plugin that provides the **`wiqd` skill**. Never use a repo-local or hand-rolled install script.
-3. **Reload skills and continue here.** The new skill isn't loaded yet — ask the user to run `/skills reload` (or reload their Copilot window), then re-send their request in this same session. Once the `wiqd` skill is available, invoke it directly and carry the request through. Never send the user to a separate session or a different entry point.
-
-> ❌ **Do not** hand-author `declarativeAgent.json` / `manifest.json` / a Teams app package yourself, and **do not** try to deploy or publish an agent through WorkIQ MCP tools — no such path exists.
-
-**Stay in WorkIQ (do NOT route to `wiqd`) when** the request is about M365 data (mail, calendar, Teams, files, people, Planner), when "agent" means this assistant with no build/ship verb, or when installing a Copilot CLI plugin from this marketplace. For mixed requests ("summarize the feedback on my agent, then publish it"), answer the WorkIQ half first, then hand off the build/publish half.
+This does **not** apply to M365 data requests, to "agent" meaning this assistant, or to installing a plugin from this marketplace — those stay in WorkIQ.
 
 ### Don't substitute web search or CLI introspection
 

--- a/plugins/workiq/skills/workiq/SKILL.md
+++ b/plugins/workiq/skills/workiq/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workiq
-description: WorkIQ - Microsoft 365 tool surface for agents. Use for any workplace question or write action where data lives in M365. Supports semantic `ask` plus tools (`fetch`, create/update/delete, actions, functions, fetch_blob, path/schema discovery) for mail, meetings/calendar, documents/files, Teams chats/channels, OneDrive/SharePoint, and people. Read triggers, "what did [person] say", priorities/top of mind, meeting decisions/action items, summarize thread/chat, find emails/docs, list meetings/messages/files/channels, project status/updates, "what changed since", download file content. Write triggers, send/reply/forward email, create/update/accept/decline meetings, mark read, delete drafts/items, send/post/reply/react in Teams, set presence. Discovery triggers, available endpoints/paths, fields, request body, schema/data model. Prefer `ask` for synthesis; use entity tools for exact reads/writes.
+description: WorkIQ - Microsoft 365 tool surface for agents. Use for any workplace question or write action where data lives in M365. Supports semantic `ask` plus tools (`fetch`, create/update/delete, actions, functions, fetch_blob, path/schema discovery) for mail, meetings/calendar, documents/files, Teams chats/channels, OneDrive/SharePoint, and people. Read triggers, "what did [person] say", priorities/top of mind, meeting decisions/action items, summarize thread/chat, find emails/docs, list meetings/messages/files/channels, project status/updates, "what changed since", download file content. Write triggers, send/reply/forward email, create/update/accept/decline meetings, mark read, delete drafts/items, send/post/reply/react in Teams, set presence. Discovery triggers, available endpoints/paths, fields, request body, schema/data model. Prefer `ask` for synthesis; use entity tools for exact reads/writes. Build/deploy/publish an agent or plugin, hand off to wiqd per references/wiqd.md.
 compatibility: >
   Uses the hosted WorkIQ MCP endpoint. No local package is required for MCP
   tool calls.
@@ -58,6 +58,7 @@ See [Resolving tool names in your host](#resolving-tool-names-in-your-host) belo
 | What's new/changed/removed since a point in time | "What's new in my Inbox since this morning?", "What's changed on my calendar since yesterday?", "What's been added to my contacts recently?" | `call_function` (delta — `/me/mailFolders/inbox/messages/delta`, `/me/calendarView/delta?...`, `/me/contacts/delta`). **Never call delta via `fetch`** — see `references/call-function-work-iq.md` |
 | Sending mail, accepting/declining meetings | "Send this draft", "Accept the 2pm meeting" | `do_action` |
 | Creating a calendar event, draft, or task | "Create a calendar event Friday at 3pm" | `create_entity` |
+| **Building/deploying/publishing a Copilot agent or plugin** | "Create a declarative agent", "publish my agent", "deploy my plugin" | **Not WorkIQ** — hand off to `wiqd`, see `references/wiqd.md` |
 
 **DO NOT say "I don't have access to emails/meetings/messages"** - use WorkIQ instead!
 
@@ -119,6 +120,35 @@ Common failure: fetching the entity and stopping, asking the user "did you want 
 - **Be precise about tool outcomes.** Do not claim success, failure, existence, or a specific error unless the exact outcome is in the tool result. On null/empty/ambiguous results, say so.
 - **Call at least one WorkIQ tool before answering any M365 question.** Exceptions: non-workplace questions, or questions about this skill's docs.
 - **Honor paging.** If a response includes `@odata.nextLink`, do not present the first page as complete. Continue fetching when the user asks for all/every/complete, or say the answer is partial.
+
+## 🚧 Building, deploying, or publishing an agent or plugin → hand off to `wiqd`
+
+WorkIQ **reads and writes M365 data**. It does **not** build, package, deploy, or publish Copilot agents or plugins. Those requests belong to **Work IQ Dev Tools (`wiqd`)**.
+
+**Route to `wiqd` when the user wants to:**
+
+| Intent | Example phrasings |
+|---|---|
+| Create / scaffold an agent or plugin | "create an agent", "new declarative agent", "scaffold a Copilot agent", "create a plugin", "new plugin project" |
+| Build / edit agent artifacts | "build my agent", "edit my agent", "add a capability", "add a knowledge source", "add an API plugin", "update the manifest" |
+| Validate / test / evaluate | "validate my agent", "run my evals", "test my agent", "debug my agent", "open devui" |
+| Provision / deploy / install / share | "provision my agent", "deploy my agent", "install my agent", "sideload my agent", "share my agent with my team" |
+| Package / publish / onboard | "package my agent", "publish my agent", "submit to AppSource", "publish to Partner Center", "onboard my agent", "start compliance review" |
+| Monitor a deployed agent | "monitor my agent", "check agent health", "talk to my deployed agent" |
+
+**Handoff procedure — read `references/wiqd.md` before acting.** In short:
+
+1. **Check first.** If a `wiqd` skill or `wiqd:wiqd` agent is already loaded, or `wiqd --version` succeeds, **do not install** — go to step 3.
+2. **Install with the official script only** (confirm with the user first):
+   - Windows: `iex "& { $(irm 'https://aka.ms/wiqd/install.ps1') }"`
+   - macOS/Linux: `curl -fsSL https://aka.ms/wiqd/install.sh | bash`
+
+   This installs the `wiqd` CLI, the VS Code extension, and the **Copilot CLI plugin that provides the `wiqd` skill**. Never use a repo-local or hand-rolled install script.
+3. **Guide the user to the skill.** A freshly installed plugin isn't active in the current session — tell the user to **restart Copilot CLI**, then continue via the skill or `copilot -i "<their request>" --agent wiqd:wiqd`. If the `wiqd` skill is already loaded, invoke it directly instead of sending the user away.
+
+> ❌ **Do not** hand-author `declarativeAgent.json` / `manifest.json` / a Teams app package yourself, and **do not** try to deploy or publish an agent through WorkIQ MCP tools — no such path exists.
+
+**Stay in WorkIQ (do NOT route to `wiqd`) when** the request is about M365 data (mail, calendar, Teams, files, people, Planner), when "agent" means this assistant with no build/ship verb, or when installing a Copilot CLI plugin from this marketplace. For mixed requests ("summarize the feedback on my agent, then publish it"), answer the WorkIQ half first, then hand off the build/publish half.
 
 ### Don't substitute web search or CLI introspection
 
@@ -403,3 +433,4 @@ Read the relevant reference file for full parameter details and examples:
 - `references/delete-entity-work-iq.md` — if you need to delete an entity
 - `references/do-action-work-iq.md` — if you need to send mail, accept/decline meetings, copy/move messages
 - `references/troubleshooting.md` — if a tool call fails unexpectedly, returns an error, or behaves differently than documented
+- `references/wiqd.md` — if the user wants to build, scaffold, validate, deploy, package, or publish a Copilot agent or plugin (hand off to Work IQ Dev Tools)

--- a/plugins/workiq/skills/workiq/references/troubleshooting.md
+++ b/plugins/workiq/skills/workiq/references/troubleshooting.md
@@ -16,7 +16,7 @@ Use this reference when a WorkIQ tool call fails or behaves unexpectedly.
 
 **Cause:** WorkIQ covers M365 *data*, not the extensibility *pipeline*. That lifecycle belongs to Work IQ Dev Tools (`wiqd`).
 
-**Fix:** Read `references/wiqd.md` and follow the handoff: check whether `wiqd` is already available; if it's missing, **ask the user to confirm before installing** (note that `wiqd` is a preview experience), then **run the official install script yourself** (`https://aka.ms/wiqd/install.ps1` on Windows, `https://aka.ms/wiqd/install.sh` on macOS/Linux) — don't leave the user to run it. Afterwards have the user reload skills (`/skills reload` or reload the Copilot window) and continue in the same session. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
+**Fix:** Read `references/wiqd.md` and follow it — it covers the availability check, the install confirmation gate, and the handoff. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
 
 ## Entity tool returns a 400 / "bad request" on a Graph URL
 

--- a/plugins/workiq/skills/workiq/references/troubleshooting.md
+++ b/plugins/workiq/skills/workiq/references/troubleshooting.md
@@ -16,7 +16,7 @@ Use this reference when a WorkIQ tool call fails or behaves unexpectedly.
 
 **Cause:** WorkIQ covers M365 *data*, not the extensibility *pipeline*. That lifecycle belongs to Work IQ Dev Tools (`wiqd`).
 
-**Fix:** Read `references/wiqd.md` and follow the handoff: check whether `wiqd` is already available, install it with the official script (`https://aka.ms/wiqd/install.ps1` on Windows, `https://aka.ms/wiqd/install.sh` on macOS/Linux) only if missing, then guide the user to restart Copilot CLI and continue through the `wiqd` skill. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
+**Fix:** Read `references/wiqd.md` and follow the handoff: check whether `wiqd` is already available, install it with the official script (`https://aka.ms/wiqd/install.ps1` on Windows, `https://aka.ms/wiqd/install.sh` on macOS/Linux) only if missing, then have the user reload skills (`/skills reload` or reload the Copilot window) and continue in the same session. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
 
 ## Entity tool returns a 400 / "bad request" on a Graph URL
 

--- a/plugins/workiq/skills/workiq/references/troubleshooting.md
+++ b/plugins/workiq/skills/workiq/references/troubleshooting.md
@@ -16,7 +16,7 @@ Use this reference when a WorkIQ tool call fails or behaves unexpectedly.
 
 **Cause:** WorkIQ covers M365 *data*, not the extensibility *pipeline*. That lifecycle belongs to Work IQ Dev Tools (`wiqd`).
 
-**Fix:** Read `references/wiqd.md` and follow the handoff: check whether `wiqd` is already available, install it with the official script (`https://aka.ms/wiqd/install.ps1` on Windows, `https://aka.ms/wiqd/install.sh` on macOS/Linux) only if missing, then have the user reload skills (`/skills reload` or reload the Copilot window) and continue in the same session. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
+**Fix:** Read `references/wiqd.md` and follow the handoff: check whether `wiqd` is already available; if it's missing, **ask the user to confirm before installing** (note that `wiqd` is a preview experience) and then use the official script only (`https://aka.ms/wiqd/install.ps1` on Windows, `https://aka.ms/wiqd/install.sh` on macOS/Linux). Afterwards have the user reload skills (`/skills reload` or reload the Copilot window) and continue in the same session. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
 
 ## Entity tool returns a 400 / "bad request" on a Graph URL
 

--- a/plugins/workiq/skills/workiq/references/troubleshooting.md
+++ b/plugins/workiq/skills/workiq/references/troubleshooting.md
@@ -10,6 +10,14 @@ Use this reference when a WorkIQ tool call fails or behaves unexpectedly.
 
 **Fix:** Scan your available-tools list for an entry whose name **ends with** the logical name (e.g., `ask`). In Copilot CLI the prefixed form is `workiq-ask`; in Claude Desktop it's `mcp__workiq__ask`. Call the exact prefixed name your host requires.
 
+## The user asked to build, deploy, or publish an agent or plugin
+
+**Symptom:** You are looking for a WorkIQ tool that scaffolds, packages, provisions, sideloads, or publishes a Copilot agent or plugin — and none exists.
+
+**Cause:** WorkIQ covers M365 *data*, not the extensibility *pipeline*. That lifecycle belongs to Work IQ Dev Tools (`wiqd`).
+
+**Fix:** Read `references/wiqd.md` and follow the handoff: check whether `wiqd` is already available, install it with the official script (`https://aka.ms/wiqd/install.ps1` on Windows, `https://aka.ms/wiqd/install.sh` on macOS/Linux) only if missing, then guide the user to restart Copilot CLI and continue through the `wiqd` skill. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
+
 ## Entity tool returns a 400 / "bad request" on a Graph URL
 
 **Symptom:** `fetch` or another entity tool returns HTTP 400 with a parser or validation error.

--- a/plugins/workiq/skills/workiq/references/troubleshooting.md
+++ b/plugins/workiq/skills/workiq/references/troubleshooting.md
@@ -16,7 +16,7 @@ Use this reference when a WorkIQ tool call fails or behaves unexpectedly.
 
 **Cause:** WorkIQ covers M365 *data*, not the extensibility *pipeline*. That lifecycle belongs to Work IQ Dev Tools (`wiqd`).
 
-**Fix:** Read `references/wiqd.md` and follow the handoff: check whether `wiqd` is already available; if it's missing, **ask the user to confirm before installing** (note that `wiqd` is a preview experience) and then use the official script only (`https://aka.ms/wiqd/install.ps1` on Windows, `https://aka.ms/wiqd/install.sh` on macOS/Linux). Afterwards have the user reload skills (`/skills reload` or reload the Copilot window) and continue in the same session. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
+**Fix:** Read `references/wiqd.md` and follow the handoff: check whether `wiqd` is already available; if it's missing, **ask the user to confirm before installing** (note that `wiqd` is a preview experience), then **run the official install script yourself** (`https://aka.ms/wiqd/install.ps1` on Windows, `https://aka.ms/wiqd/install.sh` on macOS/Linux) — don't leave the user to run it. Afterwards have the user reload skills (`/skills reload` or reload the Copilot window) and continue in the same session. Do not hand-author agent manifests or attempt deployment via WorkIQ entity tools.
 
 ## Entity tool returns a 400 / "bad request" on a Graph URL
 

--- a/plugins/workiq/skills/workiq/references/wiqd.md
+++ b/plugins/workiq/skills/workiq/references/wiqd.md
@@ -12,7 +12,8 @@ rather than *querying or acting on* M365 data.
 > Tell the user this before installing so they know what they're opting into.
 
 > 🛑 **Never install without explicit human confirmation.** Installing `wiqd` puts software on the
-> user's machine. You must ask and receive an affirmative answer first — see step 3.
+> user's machine. Ask first and wait for an affirmative answer — then **run the installer yourself**
+> rather than asking the user to run it by hand. See step 3.
 
 ## 1. Detect the intent
 
@@ -71,7 +72,7 @@ Only if step 2 found nothing.
 
 ### 🛑 Ask for confirmation first — this is a hard gate
 
-**Stop and ask the user before running anything.** Do not run the installer on your own initiative,
+**You run the installer — but only after the user says yes.** Do not run it on your own initiative,
 and do not treat the original build request ("create an agent") as consent to install software.
 
 Your confirmation prompt must state, in the user's language:
@@ -82,7 +83,7 @@ Your confirmation prompt must state, in the user's language:
 3. **What the installer does:** installs the `wiqd` CLI from npm (with the Microsoft 365 Agents
    Toolkit as a dependency), the Work IQ VS Code extension, and the plugin providing the `wiqd`
    skill.
-4. The exact command you intend to run.
+4. The exact command you will run on their behalf.
 
 Then wait for an explicit affirmative reply. Rules:
 
@@ -93,7 +94,13 @@ Then wait for an explicit affirmative reply. Rules:
 - If the user declines, **respect it**: explain that the build/publish request can't proceed without
   `wiqd`, and stop. Do not attempt the work with other tools as a workaround.
 
-### Install commands
+### Install commands — you execute these
+
+Once the user has confirmed, **run the command yourself** with your shell tool. Don't paste it and
+ask the user to run it manually, and don't end your turn waiting for them to do it — installing is
+your job from here.
+
+Pick the command for the user's platform:
 
 **Windows (PowerShell):**
 
@@ -113,6 +120,7 @@ Work IQ VS Code extension, and the plugin that provides the **`wiqd` skill**.
 Rules:
 
 - ✅ Use **only** the two commands above — they are the official, supported installers.
+- ✅ **You** execute the confirmed command; the user shouldn't have to run anything by hand.
 - ❌ Never use a repo-local `scripts/install.ps1`, a cloned build script, or a hand-rolled
   `npm install -g` variant. Those are developer-only paths.
 - **Node.js is a prerequisite.** The installer stops and points to the download if a supported

--- a/plugins/workiq/skills/workiq/references/wiqd.md
+++ b/plugins/workiq/skills/workiq/references/wiqd.md
@@ -45,17 +45,16 @@ onboard, monitor.
 
 Before installing anything, check in this order:
 
-1. **Is the wiqd skill/agent already loaded?** Scan your available skills and agents for `wiqd`
-   (e.g. a `wiqd` skill or a `wiqd:wiqd` agent). If present, **skip installation entirely** and go
-   straight to step 4.
+1. **Is the wiqd skill already loaded?** Scan your available skills for `wiqd`. If it's there,
+   **skip installation entirely** — invoke it now and let it own the request.
 2. **Is the CLI on PATH?**
 
    ```bash
    wiqd --version
    ```
 
-   If this prints a version, the CLI is installed. The Copilot plugin may still be missing — if no
-   `wiqd` skill is loaded, tell the user to restart Copilot CLI (step 4).
+   If this prints a version, the CLI is installed. The skill may still not be loaded in this
+   session — go to step 4 and have the user reload skills.
 
 Never re-run the installer when `wiqd` is already present and working.
 
@@ -77,7 +76,7 @@ curl -fsSL https://aka.ms/wiqd/install.sh | bash
 ```
 
 This installs the `wiqd` CLI from npm (with the Microsoft 365 Agents Toolkit as a dependency), the
-Work IQ VS Code extension, and the **Copilot CLI plugin** that provides the `wiqd` skill.
+Work IQ VS Code extension, and the plugin that provides the **`wiqd` skill**.
 
 Rules:
 
@@ -97,26 +96,19 @@ wiqd --version
 wiqd doctor
 ```
 
-## 4. Hand off to the wiqd skill
+## 4. Reload skills, then continue in this session
 
-The `wiqd` skill is delivered by the Copilot CLI plugin, so **a freshly installed plugin is not
-active in the current session**. Tell the user:
+The `wiqd` skill ships with the plugin the installer just added, so it isn't loaded yet. **The user
+does not need to leave this session** — they only need to pick up the new skill:
 
-1. **Restart Copilot CLI** so the newly installed `wiqd` plugin and its skill are loaded.
-2. Then continue the request through wiqd — either conversationally in a session where the skill is
-   loaded, or by routing explicitly to the orchestrator agent:
+- Run `/skills reload` (or reload the Copilot window) to load the newly installed skills.
 
-   ```bash
-   copilot -i "create a new declarative agent" --agent wiqd:wiqd
-   copilot -i "validate my agent" --agent wiqd:wiqd
-   copilot -i "publish my agent" --agent wiqd:wiqd
-   ```
+Then tell the user to **re-send their original request right here**. Once the skill is loaded,
+invoke it directly and carry the request through — do not send them to a separate session or a
+different entry point.
 
-3. Restate the user's original request in wiqd terms so they can paste it straight in
-   (e.g. "create an agent that answers HR policy questions").
-
-If the `wiqd` skill **is** already loaded in the current session, don't send the user away — invoke
-it directly and let it own the request from there.
+Restate their request in wiqd terms so they can reuse it verbatim (e.g. "create an agent that
+answers HR policy questions").
 
 Useful first commands once wiqd is available:
 

--- a/plugins/workiq/skills/workiq/references/wiqd.md
+++ b/plugins/workiq/skills/workiq/references/wiqd.md
@@ -1,0 +1,141 @@
+# Building agents & plugins — hand off to Work IQ Dev Tools (`wiqd`)
+
+WorkIQ **reads and writes Microsoft 365 data**. It does **not** build, package, deploy, or publish
+Copilot agents or plugins. Those tasks belong to **Work IQ Dev Tools (`wiqd`)** — the CLI and Copilot
+plugin that owns the full extensibility lifecycle (Build → Improve → Preview → Publish).
+
+Use this reference whenever the user's request is about *authoring or shipping* an agent/plugin
+rather than *querying or acting on* M365 data.
+
+## 1. Detect the intent
+
+Route to `wiqd` when the request matches any of these patterns.
+
+| Intent | Example phrasings |
+|---|---|
+| **Create / scaffold** an agent or plugin | "create an agent", "new declarative agent", "scaffold a Copilot agent", "start an agent project", "create a plugin", "new plugin project", "build a reusable plugin" |
+| **Build / edit** agent artifacts | "build my agent", "edit my agent", "add a capability", "add a knowledge source", "update the manifest", "add an API plugin", "add a connector", "add a skill to my plugin" |
+| **Validate / test / evaluate** | "validate my agent", "run my evals", "test my agent", "check my agent", "open devui", "debug my agent" |
+| **Provision / deploy / install** | "provision my agent", "deploy my agent", "install my agent", "sideload my agent", "upload my agent to Teams/M365", "share my agent with my team" |
+| **Package / publish / release** | "package my agent", "publish my agent", "submit to AppSource", "publish to Partner Center", "list my agent in the store", "onboard my agent", "start compliance review" |
+| **Monitor a deployed agent** | "monitor my agent", "how is my agent doing", "check agent health", "talk to my deployed agent" |
+
+**Trigger nouns:** declarative agent, custom engine agent, Copilot agent, M365 Copilot agent,
+Teams app, Copilot plugin, connector, agent manifest, `declarativeAgent.json`, `manifest.json`,
+AugLoop plugin.
+
+**Trigger verbs paired with those nouns:** create, scaffold, build, author, edit, add, validate,
+test, evaluate, provision, deploy, install, sideload, share, package, publish, submit, release,
+onboard, monitor.
+
+### Do NOT route to `wiqd` when…
+
+- The user asks about **M365 data** — mail, calendar, Teams messages, files, people, Planner tasks.
+  That is WorkIQ's job; stay in `SKILL.md`.
+- The word "agent" refers to **this** assistant or a generic AI agent, with no build/ship verb
+  ("what can you do", "act as my agent").
+- The user wants to **install a Copilot CLI plugin from this marketplace**
+  (`copilot plugin install ./plugins/...`) — that is not an agent build task.
+- "Create a task", "create an event", "send a message" — those are WorkIQ entity-tool writes.
+
+> ⚠️ **Ambiguity rule.** If a request mixes both ("summarize the feedback on my agent and then
+> publish it"), do the WorkIQ read first, then hand off the build/publish half to `wiqd`.
+
+## 2. Check whether `wiqd` is already available
+
+Before installing anything, check in this order:
+
+1. **Is the wiqd skill/agent already loaded?** Scan your available skills and agents for `wiqd`
+   (e.g. a `wiqd` skill or a `wiqd:wiqd` agent). If present, **skip installation entirely** and go
+   straight to step 4.
+2. **Is the CLI on PATH?**
+
+   ```bash
+   wiqd --version
+   ```
+
+   If this prints a version, the CLI is installed. The Copilot plugin may still be missing — if no
+   `wiqd` skill is loaded, tell the user to restart Copilot CLI (step 4).
+
+Never re-run the installer when `wiqd` is already present and working.
+
+## 3. Install `wiqd` with the official script
+
+Only if step 2 found nothing. **Ask the user to confirm before running the installer** — it
+installs software on their machine.
+
+**Windows (PowerShell):**
+
+```powershell
+iex "& { $(irm 'https://aka.ms/wiqd/install.ps1') }"
+```
+
+**macOS / Linux (bash):**
+
+```bash
+curl -fsSL https://aka.ms/wiqd/install.sh | bash
+```
+
+This installs the `wiqd` CLI from npm (with the Microsoft 365 Agents Toolkit as a dependency), the
+Work IQ VS Code extension, and the **Copilot CLI plugin** that provides the `wiqd` skill.
+
+Rules:
+
+- ✅ Use **only** the two commands above — they are the official, supported installers.
+- ❌ Never use a repo-local `scripts/install.ps1`, a cloned build script, or a hand-rolled
+  `npm install -g` variant. Those are developer-only paths.
+- **Node.js is a prerequisite.** The installer stops and points to the download if a supported
+  Node version is missing — it does **not** install Node. If that happens, relay the message and
+  stop; do not try to install Node yourself.
+- If the installer fails, report the actual error output. Do not invent a cause and do not fall
+  back to attempting the agent build yourself.
+
+Verify afterwards:
+
+```bash
+wiqd --version
+wiqd doctor
+```
+
+## 4. Hand off to the wiqd skill
+
+The `wiqd` skill is delivered by the Copilot CLI plugin, so **a freshly installed plugin is not
+active in the current session**. Tell the user:
+
+1. **Restart Copilot CLI** so the newly installed `wiqd` plugin and its skill are loaded.
+2. Then continue the request through wiqd — either conversationally in a session where the skill is
+   loaded, or by routing explicitly to the orchestrator agent:
+
+   ```bash
+   copilot -i "create a new declarative agent" --agent wiqd:wiqd
+   copilot -i "validate my agent" --agent wiqd:wiqd
+   copilot -i "publish my agent" --agent wiqd:wiqd
+   ```
+
+3. Restate the user's original request in wiqd terms so they can paste it straight in
+   (e.g. "create an agent that answers HR policy questions").
+
+If the `wiqd` skill **is** already loaded in the current session, don't send the user away — invoke
+it directly and let it own the request from there.
+
+Useful first commands once wiqd is available:
+
+```bash
+wiqd auth login              # sign in
+wiqd agent create --name my-first-agent
+wiqd agent validate
+wiqd agent provision
+```
+
+Docs: <https://aka.ms/wiqd/docs>
+
+## 5. What you must not do
+
+- ❌ Do **not** hand-author `declarativeAgent.json`, `manifest.json`, or a Teams app package from
+  scratch when `wiqd` can scaffold it. The manifests are versioned and schema-validated; hand-rolled
+  files silently break provisioning and publishing.
+- ❌ Do **not** use WorkIQ MCP tools (`fetch`, `create_entity`, `do_action`, …) to try to deploy,
+  sideload, or publish an agent. There is no such path — WorkIQ speaks to M365 data, not to the
+  extensibility pipeline.
+- ❌ Do **not** substitute a generic web search or a different toolkit as a workaround when the
+  install fails. Report the failure and let the user decide.

--- a/plugins/workiq/skills/workiq/references/wiqd.md
+++ b/plugins/workiq/skills/workiq/references/wiqd.md
@@ -7,6 +7,13 @@ plugin that owns the full extensibility lifecycle (Build → Improve → Preview
 Use this reference whenever the user's request is about *authoring or shipping* an agent/plugin
 rather than *querying or acting on* M365 data.
 
+> ⚠️ **Preview experience.** Work IQ Dev Tools (`wiqd`) is in **preview**. Behavior, commands, and
+> the install surface can change without notice, and some capabilities are gated or incomplete.
+> Tell the user this before installing so they know what they're opting into.
+
+> 🛑 **Never install without explicit human confirmation.** Installing `wiqd` puts software on the
+> user's machine. You must ask and receive an affirmative answer first — see step 3.
+
 ## 1. Detect the intent
 
 Route to `wiqd` when the request matches any of these patterns.
@@ -60,8 +67,33 @@ Never re-run the installer when `wiqd` is already present and working.
 
 ## 3. Install `wiqd` with the official script
 
-Only if step 2 found nothing. **Ask the user to confirm before running the installer** — it
-installs software on their machine.
+Only if step 2 found nothing.
+
+### 🛑 Ask for confirmation first — this is a hard gate
+
+**Stop and ask the user before running anything.** Do not run the installer on your own initiative,
+and do not treat the original build request ("create an agent") as consent to install software.
+
+Your confirmation prompt must state, in the user's language:
+
+1. That `wiqd` is **not installed** and is required to continue.
+2. That Work IQ Dev Tools is a **preview experience** — commands and behavior may change, and some
+   capabilities are gated or incomplete.
+3. **What the installer does:** installs the `wiqd` CLI from npm (with the Microsoft 365 Agents
+   Toolkit as a dependency), the Work IQ VS Code extension, and the plugin providing the `wiqd`
+   skill.
+4. The exact command you intend to run.
+
+Then wait for an explicit affirmative reply. Rules:
+
+- ✅ Proceed only on a clear yes ("yes", "go ahead", "install it").
+- ❌ Silence, ambiguity, a question, or "maybe later" is **not** consent — do not install.
+- ❌ Never auto-approve, never assume consent from context, and never re-ask repeatedly to wear the
+  user down.
+- If the user declines, **respect it**: explain that the build/publish request can't proceed without
+  `wiqd`, and stop. Do not attempt the work with other tools as a workaround.
+
+### Install commands
 
 **Windows (PowerShell):**
 


### PR DESCRIPTION
## Summary

WorkIQ covers Microsoft 365 **data**, not the Copilot extensibility **pipeline**. Today, when a user asks the workiq skill to *create*, *build*, *deploy*, *install*, or *publish* an agent or plugin, nothing routes them anywhere — the model may hand-author manifests or hunt for a WorkIQ tool that does not exist.

This PR adds explicit intent detection and a handoff to **Work IQ Dev Tools (`wiqd`)**.

## Changes

- **New `skills/workiq/references/wiqd.md`** — the full handoff reference:
  - Intent detection table (create/scaffold, build/edit, validate/test, provision/deploy/install/share, package/publish/onboard, monitor) with example phrasings and trigger nouns/verbs
  - Explicit **negative** cases so M365 data questions, `copilot plugin install`, and "create a task/event" stay in WorkIQ
  - Check-before-install: skip installation when the `wiqd` skill/`wiqd:wiqd` agent is loaded or `wiqd --version` succeeds
  - Install via the **official scripts only** (`https://aka.ms/wiqd/install.ps1` / `https://aka.ms/wiqd/install.sh`), with the Node prerequisite and the "never use repo-local build scripts" guard
  - Post-install guidance: restart Copilot CLI so the plugin's skill loads, then continue via the skill or `copilot -i "..." --agent wiqd:wiqd`
  - Guardrails: don't hand-author `declarativeAgent.json`/`manifest.json`, don't attempt deployment through WorkIQ MCP tools
- **`SKILL.md`** — new routing section, a row in the "when to use this skill" table, an entry in the reference index, and the handoff trigger appended to the frontmatter description (987/1024 chars, within the runtime limit)
- **`references/troubleshooting.md`** — entry for "the user asked to build/deploy/publish an agent"
- **`plugins/workiq/README.md`** — documents the handoff and the install commands

## Notes

No MCP tool surface or version change — this is skill guidance only.